### PR TITLE
RFC: The Next.js "App Router", React Server Component & "SSR with Suspense" story

### DIFF
--- a/RFC.md
+++ b/RFC.md
@@ -45,6 +45,10 @@ export default function Layout() {
 }
 
 // Page.js
+
+// this is imported from a Client file, so it will be handled as a Client Component
+import { Collapsible } from "./Collapsible"; 
+
 export default function Page() {
   return (
     <main>
@@ -107,7 +111,7 @@ This JSX can be handled in multiple ways:
 * It could be evaluated for an SSR pass on the server (e.g., on first page load) and be streamed to the browser as HTML, where the components will get hydrated.
 * It could be transformed into a React-specific JSON format and sent to the browser, where it will be evaluated by the client component layer.
 
-It is important to note that we have a unidirectional dataflow here: (serializable) props can flow from the RSC layer to Client Components, but nothing can flow from Client Components back into RSC.
+It is important to note that we have a unidirectional dataflow here: (serializable) props can flow from the RSC layer to Client Components, but nothing can flow from Client Components back into RSC. (We do not yet cover Server Actions, as these were released a few days ago as of writing this.)
 
 
 


### PR DESCRIPTION
## The RFC 

[You can read the rendered RFC here.](https://github.com/apollographql/apollo-client-nextjs/blob/pr/RFC-2/RFC.md)

### The examples

You can find some example applications in [the examples folder](https://github.com/apollographql/apollo-client-nextjs/tree/main/examples).

* The `polls-demo` is a simple poll app that showcases both Server Components and Client Components in a single app. It shows the difference between using Apollo Client in Server Components and Client Components.
* The `hack-the-supergraph-ssr` example is an example exploring the "SSR and data transporting" angle more in-depth. It also uses the `@defer`-related Links discussed in the last part of the RFC.  
  You can change the time deferred responses from the server take by adjusting it in the "Demo Settings" in the top-right corner. The link is configured so that any fragment coming in after 100ms will not be part of SSR, but be fetched on the client. Keep in mind that this uses a real network connection, so there might be some network delay on top of the number you choose here.
* The `app-dir-experiments` is more of an "experimenting around" app I used for building the package

## Points to look out for

* Starting the examples for the first time in `next` oftentimes leads to a hydration mismatch. This is due to `useId` not matching up between client and server. I assume that this could be a Next.js bug and have filed a bug report here: https://github.com/vercel/next.js/issues/48284
We track this in this issue in #16