### PR TITLE
Add prebuild command for examples

### DIFF
--- a/examples/app-dir-experiments/package.json
+++ b/examples/app-dir-experiments/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "yarn workspace @apollo/experimental-nextjs-app-support run build",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/hack-the-supergraph-ssr/package.json
+++ b/examples/hack-the-supergraph-ssr/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "yarn workspace @apollo/experimental-nextjs-app-support run build",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/examples/polls-demo/package.json
+++ b/examples/polls-demo/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "yarn workspace @apollo/experimental-nextjs-app-support run build",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
@phryneas looks like I need to run 

```
yarn workspace @apollo/experimental-nextjs-app-support run build
```

before running build, so I've added it as a prebuild script (so that the deploy on vercel doesn't fail) :)

does it make sense? should I add it to the other examples too?