### PR TITLE
(do not merge) schemalink in app-dir-experiments

### DIFF
--- a/examples/app-dir-experiments/app/ApolloClient.ts
+++ b/examples/app-dir-experiments/app/ApolloClient.ts
@@ -1,14 +1,11 @@
-import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client";
+import { ApolloClient, InMemoryCache } from "@apollo/client";
+import { SchemaLink } from "@apollo/client/link/schema";
 import { registerApolloClient } from "@apollo/experimental-nextjs-app-support/rsc";
+import { schema } from "./api/graphql/route";
 
 export const { getClient } = registerApolloClient(() => {
   return new ApolloClient({
     cache: new InMemoryCache(),
-    link: new HttpLink({
-      uri: "http://localhost:3000/api/graphql",
-      // you can disable result caching here if you want to
-      // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
-      // fetchOptions: { cache: "no-store" },
-    }),
+    link: new SchemaLink({ schema }),
   });
 });

--- a/examples/app-dir-experiments/app/api/graphql/route.ts
+++ b/examples/app-dir-experiments/app/api/graphql/route.ts
@@ -1,5 +1,6 @@
 import { startServerAndCreateNextHandler } from "@as-integrations/next";
 import { ApolloServer } from "@apollo/server";
+import { makeExecutableSchema } from "@graphql-tools/schema";
 import { gql } from "graphql-tag";
 
 const typeDefs = gql`
@@ -37,9 +38,13 @@ const resolvers = {
   },
 };
 
-const server = new ApolloServer({
-  resolvers,
+export const schema = makeExecutableSchema({
   typeDefs,
+  resolvers,
+});
+
+const server = new ApolloServer({
+  schema,
 });
 
 const handler = startServerAndCreateNextHandler(server);

--- a/examples/app-dir-experiments/app/ssr/ApolloWrapper.tsx
+++ b/examples/app-dir-experiments/app/ssr/ApolloWrapper.tsx
@@ -6,21 +6,18 @@ import {
   HttpLink,
   SuspenseCache,
 } from "@apollo/client";
+import { SchemaLink } from "@apollo/client/link/schema";
 import {
   ApolloNextAppProvider,
   NextSSRInMemoryCache,
   SSRMultipartLink,
 } from "@apollo/experimental-nextjs-app-support/ssr";
 import { setVerbosity } from "ts-invariant";
+import { schema } from "../api/graphql/route";
 
 setVerbosity("debug");
 
 function makeClient() {
-  const httpLink = new HttpLink({
-    uri: "http://localhost:3000/api/graphql",
-    fetchOptions: { cache: "no-store" },
-  });
-
   return new ApolloClient({
     cache: new NextSSRInMemoryCache(),
     link:
@@ -29,9 +26,14 @@ function makeClient() {
             new SSRMultipartLink({
               stripDefer: true,
             }),
-            httpLink,
+            new SchemaLink({
+              schema,
+            }),
           ])
-        : httpLink,
+        : new HttpLink({
+            uri: "http://localhost:3000/api/graphql",
+            fetchOptions: { cache: "no-store" },
+          }),
   });
 }
 


### PR DESCRIPTION
@patrick91 This came up in #31 and could be an elegant solution to have the GraphQL api in a Route Handler file, while using it from the server (and also having it accessible during build).
I don't really want to add it to the `app-dir-experiments` example, but it might be worth adding that to the `polls` demo - what do you think?