### PR TITLE
call `cache.write` independently of `resolve` presence

### DIFF
--- a/package/src/ssr/NextSSRApolloClient.tsx
+++ b/package/src/ssr/NextSSRApolloClient.tsx
@@ -135,12 +135,12 @@ export class NextSSRApolloClient<
             resolve({
               data: data.result,
             });
-            // In order to avoid a scenario where the promise resolves without
-            // a query subscribing to the promise, we immediately call
-            // `cache.write` here.
-            // For more information, see: https://github.com/apollographql/apollo-client-nextjs/pull/38/files/388813a16e2ac5c62408923a1face9ae9417d92a#r1229870523
-            this.cache.write(data);
           }
+          // In order to avoid a scenario where the promise resolves without
+          // a query subscribing to the promise, we immediately call
+          // `cache.write` here.
+          // For more information, see: https://github.com/apollographql/apollo-client-nextjs/pull/38/files/388813a16e2ac5c62408923a1face9ae9417d92a#r1229870523
+          this.cache.write(data);
         });
       }
     }


### PR DESCRIPTION
I just noticed this one when setting up our integration tests.

https://github.com/apollographql/apollo-client/blob/pr/bundling-integrations/integration-tests/next/tests/playwright/apollo-client.test.ts#L10-L14