### PR TITLE
Bump peer dependency range version allowed for `@apollo/client` package

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/experimental-nextjs-app-support",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "repository": {
     "url": "git+https://github.com/apollographql/apollo-client-nextjs"
   },
@@ -59,7 +59,7 @@
     "vitest": "^0.30.1"
   },
   "peerDependencies": {
-    "@apollo/client": ">=3.8.0-beta.4",
+    "@apollo/client": ">=3.8.0-beta.4 || >=3.8.0-rc || ^3.8.0",
     "next": "^13.4.1",
     "react": "^18"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,7 +132,7 @@ __metadata:
     typescript: ^5.0.2
     vitest: ^0.30.1
   peerDependencies:
-    "@apollo/client": ">=3.8.0-beta.4"
+    "@apollo/client": ">=3.8.0-beta.4 || >=3.8.0-rc || ^3.8.0"
     next: ^13.4.1
     react: ^18
   languageName: unknown


### PR DESCRIPTION
#57 accidentally bumped only the dev dependency version range of `@apollo/client`, but failed to increase the peer dependency range.