### PR TITLE
Allow args on function passed to registerApolloClient

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -71,6 +71,17 @@ You can then use that `getClient` function in your server components:
 const { data } = await getClient().query({ query: userQuery });
 ```
 
+#### Multiple clients
+
+If you need to manage multiple clients, for example if you have different endpoints for content previews,
+the function you pass to `registerApolloClient` can accept arbitrary arguments.
+If you're using Typescript, you can hint their types as a tuple:
+
+```ts
+export const { getClient } = registerApolloClient<[string | null]>((previewToken: string | null) => {
+  ...
+});
+
 ### In SSR
 
 If you use the `app` directory, each Client Component _will_ be SSR-rendered for the initial request. So you will need to use this package.

--- a/package/README.md
+++ b/package/README.md
@@ -79,7 +79,7 @@ If you're using Typescript, you can hint their types as a tuple:
 
 ```ts
 export const { getClient } = registerApolloClient<[string | null]>((previewToken: string | null) => {
-  ...
+  // ...
 });
 
 ### In SSR

--- a/package/src/rsc/registerApolloClient.tsx
+++ b/package/src/rsc/registerApolloClient.tsx
@@ -11,7 +11,7 @@ function assertRSC(
   }
 }
 
-export function registerApolloClient(makeClient: () => ApolloClient<any>) {
+export function registerApolloClient<Args extends any[] = any[]>(makeClient: (...args: Args) => ApolloClient<any>) {
   assertRSC(React);
   const getClient = React.cache(makeClient);
   return {


### PR DESCRIPTION
This allows the user to have separate clients based on arguments passed, in order to achieve things such as content previews.

Closes #67