### PR TITLE
README: Fix js to jsx for SSR

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -75,7 +75,7 @@ const { data } = await getClient().query({ query: userQuery });
 
 If you use the `app` directory, each Client Component _will_ be SSR-rendered for the initial request. So you will need to use this package.
 
-First, create a new file `app/ApolloWrapper.js`:
+First, create a new file `app/ApolloWrapper.jsx`:
 
 ```js
 "use client";


### PR DESCRIPTION
### Why is the change needed
Changing the README to specify that we should use the filename `app/ApolloWrapper.jsx` instead of `app/ApolloWrapper.js` in the _**In SSR**_ section, because there is a React component in there, and we will get `Parsing error: '>' expected eslint` error when it's in `.js` (EDIT: correction it'll only error in Typescript files)

![apollowrapper](https://github.com/apollographql/apollo-client-nextjs/assets/78723468/ca07f3ce-c07b-46a3-acda-9c341abc52a3)
I am using Typescript in this file

### What I have changed
- `.js` to `.jsx` in the _**In SSR**_ section
