### PR TITLE
fix: tag snapshot npm releases with snapshot tag instead of latest

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -41,7 +41,7 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn workspace @apollo/experimental-nextjs-app-support version "0.0.0-commit-$(git rev-parse --short HEAD)"
-      - run: yarn workspace @apollo/experimental-nextjs-app-support exec npm publish --access public  --provenance
+      - run: yarn workspace @apollo/experimental-nextjs-app-support exec npm publish --access public --tag snapshot --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
Just noticed a snapshot release was tagged with `latest` when I just `npm i`'d the library. We don't need every snapshot release to have its own tag (this list would grow infinitely on our npm page while providing basically no utility), so I went with the generic `snapshot` tag that will be shared across all snapshot releases.