### PR TITLE
chore: remove experimental flag as it's stable now

### DIFF
--- a/examples/app-dir-experiments/next.config.js
+++ b/examples/app-dir-experiments/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/examples/hack-the-supergraph-ssr/next.config.js
+++ b/examples/hack-the-supergraph-ssr/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
-};
+const nextConfig = {}
 
-module.exports = nextConfig;
+module.exports = nextConfig


### PR DESCRIPTION
I wasn't able to properly test, but on my own separate Next.js instance with the same npm versions works flawflessly without the `appDir: true` flag.

As seen enclosed in the "Good to know" callout:
https://nextjs.org/docs/app/api-reference/next-config-js/appDir