### PR TITLE
Update README.md to remove Apollo Client rc warning

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -9,8 +9,6 @@
 > This cannot be addressed from our side, but would need API changes in Next.js or React itself.  
 > If you do not use suspense in your application, this will not be a problem to you.  
 
-> ❗️ This package depends on Apollo Client 3.8, which is currently an rc release.
-
 ## Detailed technical breakdown
 
 You can find a detailed technical breakdown of what this package does and why it needs to do so [in the discussion around the accompanying RFC](https://github.com/apollographql/apollo-client-nextjs/pull/9).


### PR DESCRIPTION
Apollo 3.8.0 was [released](https://github.com/apollographql/apollo-client/releases/tag/v3.8.0). The rc release warning is no longer needed.
