### PR TITLE
Use server-only package instead of custom environment detection

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -64,6 +64,7 @@
     "react": "^18"
   },
   "dependencies": {
+    "server-only": "^0.0.1",
     "superjson": "^1.12.2",
     "ts-invariant": "^0.10.3"
   }

--- a/package/src/rsc/registerApolloClient.tsx
+++ b/package/src/rsc/registerApolloClient.tsx
@@ -1,18 +1,9 @@
+import "server-only";
+
 import type { ApolloClient } from "@apollo/client";
 import * as React from "react";
 
-function assertRSC(
-  reactImport: typeof import("react")
-): asserts reactImport is typeof import("react") & { cache<T>(x: () => T): T } {
-  if ("createContext" in React) {
-    throw new Error(
-      "`registerApolloClient` should only be used in a React Server Component context - in Client Components, use the `ApolloNextAppProvider`!"
-    );
-  }
-}
-
 export function registerApolloClient(makeClient: () => ApolloClient<any>) {
-  assertRSC(React);
   const getClient = React.cache(makeClient);
   return {
     getClient,

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,7 @@ __metadata:
     next: ^13.4.4
     react: ^18.2.0
     rimraf: ^5.0.0
+    server-only: ^0.0.1
     superjson: ^1.12.2
     ts-invariant: ^0.10.3
     ts-node: ^10.9.1


### PR DESCRIPTION
I saw this issue when trying to fetch data from the `sitemap.ts` file using the `getClient` / `registerApolloClient` (like it's done for server only code).
Apparently the "client version" of React is somehow available when the sitemap is getting generated which was triggering the custom detection currently implemented.

I tried using `import 'server-only` instead as it is the recommended way to make sure something isn't imported from a client component and all cases seem to work:
- From CC -> crash (✅ )
- From RSC -> ✅ 
- From sitemap.ts -> ✅ 