### PR TITLE
prepare for change in `QueryManager.inFlightLinkObservable` (Apollo Client 3.9 beta)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,10 @@ jobs:
     name: Run unit tests
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["latest", "next", "0.0.0-pr-11345-20231129164802"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -21,11 +25,16 @@ jobs:
           node-version: "18.x"
           cache: "yarn"
       - run: yarn install --immutable
+      - run: yarn workspace @apollo/experimental-nextjs-app-support add -D -P @apollo/client@${{ matrix.version }}
       - run: yarn workspace @apollo/experimental-nextjs-app-support run test > $GITHUB_STEP_SUMMARY
   tests_playwright:
     name: Run Playwright tests
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["latest", "next", "0.0.0-pr-11345-20231129164802"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -48,6 +57,9 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
       - run: npx playwright install-deps
         if: steps.playwright-cache.outputs.cache-hit == 'true'
+
+      - run: yarn workspace @apollo/experimental-nextjs-app-support add -D -P @apollo/client@${{ matrix.version }}
+      - run: yarn workspace integration-test add @apollo/client@${{ matrix.version }}
 
       - name: Build
         run: yarn workspaces foreach -R -t --from integration-test run build

--- a/package/src/ssr/NextSSRApolloClient.tsx
+++ b/package/src/ssr/NextSSRApolloClient.tsx
@@ -20,7 +20,7 @@ import invariant from "ts-invariant";
 
 function getQueryManager<TCacheShape>(
   client: ApolloClient<unknown>
-): QueryManager<TCacheShape> {
+): QueryManager<TCacheShape> | any {
   return client["queryManager"];
 }
 


### PR DESCRIPTION
See changes in https://github.com/apollographql/apollo-client/pull/11345

Unfortunately, we already bumped the dependencies for the alphas/betas/rcs, so we can't just force an update that way.