### PR TITLE
feat: add support for passing a nonce to the rehydration script

### DIFF
--- a/integration-test/.env.local
+++ b/integration-test/.env.local
@@ -1,0 +1,1 @@
+SECRET={"alg":"A256CBC","ext":true,"k":"yZrgd8urZnVpOSjC22EUNIDJZbmvEL4xApt_eraMsaU","key_ops":["encrypt","decrypt"],"kty":"oct"}

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -23,6 +23,7 @@
     "next": "^14.0.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "ssr-only-secrets": "^0.0.5",
     "typescript": "5.1.3"
   },
   "devDependencies": {

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -20,7 +20,7 @@
     "@types/react-dom": "18.2.6",
     "graphql": "^16.7.1",
     "graphql-tag": "^2.12.6",
-    "next": "^14.0.0",
+    "next": "^14.0.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "typescript": "5.1.3"

--- a/integration-test/src/app/cc/ApolloWrapper.tsx
+++ b/integration-test/src/app/cc/ApolloWrapper.tsx
@@ -18,9 +18,17 @@ setVerbosity("debug");
 loadDevMessages();
 loadErrorMessages();
 
-export function ApolloWrapper({ children }: React.PropsWithChildren<{}>) {
+export function ApolloWrapper({
+  children,
+  nonce,
+}: React.PropsWithChildren<{ nonce?: string }>) {
   return (
-    <ApolloNextAppProvider makeClient={makeClient}>
+    <ApolloNextAppProvider
+      makeClient={makeClient}
+      extraScriptProps={{
+        nonce,
+      }}
+    >
       {children}
     </ApolloNextAppProvider>
   );

--- a/integration-test/src/app/cc/ApolloWrapper.tsx
+++ b/integration-test/src/app/cc/ApolloWrapper.tsx
@@ -12,7 +12,9 @@ import { SchemaLink } from "@apollo/client/link/schema";
 import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
 import { setVerbosity } from "ts-invariant";
 import { delayLink } from "@/shared/delayLink";
-import { schema } from "../graphql/route";
+import { schema } from "../graphql/schema";
+
+import { useSSROnlySecret } from "ssr-only-secrets";
 
 setVerbosity("debug");
 loadDevMessages();
@@ -22,11 +24,12 @@ export function ApolloWrapper({
   children,
   nonce,
 }: React.PropsWithChildren<{ nonce?: string }>) {
+  const actualNonce = useSSROnlySecret(nonce, "SECRET");
   return (
     <ApolloNextAppProvider
       makeClient={makeClient}
       extraScriptProps={{
-        nonce,
+        nonce: actualNonce,
       }}
     >
       {children}

--- a/integration-test/src/app/cc/dynamic/dynamic.test.ts
+++ b/integration-test/src/app/cc/dynamic/dynamic.test.ts
@@ -59,4 +59,31 @@ test.describe("CC dynamic", () => {
       await expect(page.getByText("Soft Warm Apollo Beanie")).toBeVisible();
     });
   });
+  test.describe("useSuspenseQuery with a nonce", () => {
+    test("invalid: logs an error", async ({ page, blockRequest }) => {
+      await page.goto(
+        "http://localhost:3000/cc/dynamic/useSuspenseQuery?nonce=invalid",
+        {
+          waitUntil: "commit",
+        }
+      );
+
+      const messagePromise = page.waitForEvent("console");
+      const message = await messagePromise;
+      expect(message.text()).toMatch(
+        /^Refused to execute inline script because it violates the following Content Security Policy/
+      );
+    });
+    test("valid: does not log an error", async ({ page, blockRequest }) => {
+      await page.goto(
+        "http://localhost:3000/cc/dynamic/useSuspenseQuery?nonce=8IBTHwOdqNKAWeKl7plt8g==",
+        {
+          waitUntil: "commit",
+        }
+      );
+
+      const messagePromise = page.waitForEvent("console");
+      expect(messagePromise).rejects.toThrow(/waiting for event \"console\"/);
+    });
+  });
 });

--- a/integration-test/src/app/cc/dynamic/layout.tsx
+++ b/integration-test/src/app/cc/dynamic/layout.tsx
@@ -1,7 +1,9 @@
 import { headers } from "next/headers";
+import { ApolloWrapper } from "../ApolloWrapper";
 
 export default function Layout({ children }: React.PropsWithChildren) {
   // force this into definitely rendering on the server, and dynamically
   console.log(headers().toString().substring(0, 0));
-  return children;
+  const nonce = headers().get("x-nonce-param") ?? undefined;
+  return <ApolloWrapper nonce={nonce}>{children}</ApolloWrapper>;
 }

--- a/integration-test/src/app/cc/dynamic/layout.tsx
+++ b/integration-test/src/app/cc/dynamic/layout.tsx
@@ -1,9 +1,16 @@
 import { headers } from "next/headers";
 import { ApolloWrapper } from "../ApolloWrapper";
+import { cloakSSROnlySecret } from "ssr-only-secrets";
 
-export default function Layout({ children }: React.PropsWithChildren) {
+export default async function Layout({ children }: React.PropsWithChildren) {
   // force this into definitely rendering on the server, and dynamically
   console.log(headers().toString().substring(0, 0));
   const nonce = headers().get("x-nonce-param") ?? undefined;
-  return <ApolloWrapper nonce={nonce}>{children}</ApolloWrapper>;
+  return (
+    <ApolloWrapper
+      nonce={nonce ? await cloakSSROnlySecret(nonce, "SECRET") : undefined}
+    >
+      {children}
+    </ApolloWrapper>
+  );
 }

--- a/integration-test/src/app/cc/static/layout.tsx
+++ b/integration-test/src/app/cc/static/layout.tsx
@@ -1,4 +1,4 @@
-import { ApolloWrapper } from "./ApolloWrapper";
+import { ApolloWrapper } from "../ApolloWrapper";
 
 export default async function Layout({
   children,

--- a/integration-test/src/app/graphql/route.ts
+++ b/integration-test/src/app/graphql/route.ts
@@ -1,53 +1,6 @@
 import { startServerAndCreateNextHandler } from "@as-integrations/next";
 import { ApolloServer } from "@apollo/server";
-import { makeExecutableSchema } from "@graphql-tools/schema";
-import { gql } from "graphql-tag";
-
-const typeDefs = gql`
-  type Product {
-    id: String!
-    title: String!
-  }
-  type Query {
-    products: [Product!]!
-  }
-`;
-
-const resolvers = {
-  Query: {
-    products: async () => [
-      {
-        id: "product:5",
-        title: "Soft Warm Apollo Beanie",
-      },
-      {
-        id: "product:2",
-        title: "Stainless Steel Water Bottle",
-      },
-      {
-        id: "product:3",
-        title: "Athletic Baseball Cap",
-      },
-      {
-        id: "product:4",
-        title: "Baby Onesies",
-      },
-      {
-        id: "product:1",
-        title: "The Apollo T-Shirt",
-      },
-      {
-        id: "product:6",
-        title: "The Apollo Socks",
-      },
-    ],
-  },
-};
-
-export const schema = makeExecutableSchema({
-  typeDefs,
-  resolvers,
-});
+import { schema } from "./schema";
 
 const server = new ApolloServer({
   schema,

--- a/integration-test/src/app/graphql/schema.ts
+++ b/integration-test/src/app/graphql/schema.ts
@@ -1,0 +1,48 @@
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import gql from "graphql-tag";
+
+const typeDefs = gql`
+  type Product {
+    id: String!
+    title: String!
+  }
+  type Query {
+    products: [Product!]!
+  }
+`;
+
+const resolvers = {
+  Query: {
+    products: async () => [
+      {
+        id: "product:5",
+        title: "Soft Warm Apollo Beanie",
+      },
+      {
+        id: "product:2",
+        title: "Stainless Steel Water Bottle",
+      },
+      {
+        id: "product:3",
+        title: "Athletic Baseball Cap",
+      },
+      {
+        id: "product:4",
+        title: "Baby Onesies",
+      },
+      {
+        id: "product:1",
+        title: "The Apollo T-Shirt",
+      },
+      {
+        id: "product:6",
+        title: "The Apollo Socks",
+      },
+    ],
+  },
+};
+
+export const schema = makeExecutableSchema({
+  typeDefs,
+  resolvers,
+});

--- a/integration-test/src/app/rsc/client.ts
+++ b/integration-test/src/app/rsc/client.ts
@@ -6,7 +6,7 @@ import { setVerbosity } from "ts-invariant";
 import { delayLink } from "@/shared/delayLink";
 import { SchemaLink } from "@apollo/client/link/schema";
 
-import { schema } from "../graphql/route";
+import { schema } from "../graphql/schema";
 
 setVerbosity("debug");
 loadDevMessages();

--- a/integration-test/src/middleware.ts
+++ b/integration-test/src/middleware.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const nonce = request.nextUrl.searchParams.get("nonce");
+  if (nonce) {
+    // we set a fixed nonce here so we can test correct and incorrect nonce values
+    const validNonce = "8IBTHwOdqNKAWeKl7plt8g==";
+    // 'unsafe-eval' for `react-refresh`
+    const contentSecurityPolicyHeaderValue = `default-src 'self'; script-src 'nonce-${validNonce}' 'strict-dynamic' 'unsafe-eval';`;
+
+    const requestHeaders = new Headers(request.headers);
+    // valid nonce for next
+    requestHeaders.set("x-nonce", validNonce);
+    // potentially invalid nonce for `ApolloNextAppProvider`
+    requestHeaders.set("x-nonce-param", nonce);
+    requestHeaders.set(
+      "Content-Security-Policy",
+      contentSecurityPolicyHeaderValue
+    );
+
+    const response = NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    });
+    response.headers.set(
+      "Content-Security-Policy",
+      contentSecurityPolicyHeaderValue
+    );
+
+    return response;
+  }
+}

--- a/package/src/ssr/ApolloNextAppProvider.tsx
+++ b/package/src/ssr/ApolloNextAppProvider.tsx
@@ -16,8 +16,10 @@ declare global {
 export const ApolloNextAppProvider = ({
   makeClient,
   children,
+  nonce,
 }: React.PropsWithChildren<{
   makeClient: () => ApolloClient<any>;
+  nonce?: string
 }>) => {
   const clientRef = React.useRef<ApolloClient<any>>();
 
@@ -31,7 +33,7 @@ export const ApolloNextAppProvider = ({
 
   return (
     <_ApolloProvider client={clientRef.current}>
-      <RehydrationContextProvider>{children}</RehydrationContextProvider>
+      <RehydrationContextProvider nonce={nonce}>{children}</RehydrationContextProvider>
     </_ApolloProvider>
   );
 };

--- a/package/src/ssr/ApolloNextAppProvider.tsx
+++ b/package/src/ssr/ApolloNextAppProvider.tsx
@@ -4,7 +4,10 @@ import {
   ApolloClient,
   ApolloProvider as _ApolloProvider,
 } from "@apollo/client";
-import { RehydrationContextProvider } from "./RehydrationContext";
+import {
+  HydrationContextOptions,
+  RehydrationContextProvider,
+} from "./RehydrationContext";
 
 export const ApolloClientSingleton = Symbol.for("ApolloClientSingleton");
 
@@ -16,11 +19,12 @@ declare global {
 export const ApolloNextAppProvider = ({
   makeClient,
   children,
-  nonce,
-}: React.PropsWithChildren<{
-  makeClient: () => ApolloClient<any>;
-  nonce?: string
-}>) => {
+  ...hydrationContextOptions
+}: React.PropsWithChildren<
+  {
+    makeClient: () => ApolloClient<any>;
+  } & HydrationContextOptions
+>) => {
   const clientRef = React.useRef<ApolloClient<any>>();
 
   if (typeof window !== "undefined") {
@@ -33,7 +37,9 @@ export const ApolloNextAppProvider = ({
 
   return (
     <_ApolloProvider client={clientRef.current}>
-      <RehydrationContextProvider nonce={nonce}>{children}</RehydrationContextProvider>
+      <RehydrationContextProvider {...hydrationContextOptions}>
+        {children}
+      </RehydrationContextProvider>
     </_ApolloProvider>
   );
 };

--- a/package/src/ssr/RehydrationContext.tsx
+++ b/package/src/ssr/RehydrationContext.tsx
@@ -13,12 +13,13 @@ const ApolloRehydrationContext = React.createContext<
 
 export const RehydrationContextProvider = ({
   children,
-}: React.PropsWithChildren) => {
+  nonce,
+}: React.PropsWithChildren<{nonce?: string}>) => {
   const client = useApolloClient();
   const rehydrationContext = React.useRef<RehydrationContextValue>();
   if (typeof window == "undefined") {
     if (!rehydrationContext.current) {
-      rehydrationContext.current = buildApolloRehydrationContext();
+      rehydrationContext.current = buildApolloRehydrationContext(nonce);
     }
     if (client instanceof NextSSRApolloClient) {
       client.setRehydrationContext(rehydrationContext.current);
@@ -62,7 +63,7 @@ export function useRehydrationContext(): RehydrationContextValue | undefined {
   return rehydrationContext;
 }
 
-function buildApolloRehydrationContext(): RehydrationContextValue {
+function buildApolloRehydrationContext(nonce?: string): RehydrationContextValue {
   const rehydrationContext: RehydrationContextValue = {
     currentlyInjected: false,
     transportValueData: {},
@@ -109,6 +110,7 @@ function buildApolloRehydrationContext(): RehydrationContextValue {
       rehydrationContext.incomingBackgroundQueries = [];
       return (
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html,
           }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,6 +3557,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/env@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/env@npm:14.0.4"
+  checksum: 781eede471730264812d8c744d33eb42da997b4403b06a5b0e58597645152af21f3619a6cb8fc0ba1c1b26d89910c0a8ade6d4242ae13d0b7baa70e3a83cac0f
+  languageName: node
+  linkType: hard
+
 "@next/eslint-plugin-next@npm:13.2.4":
   version: 13.2.4
   resolution: "@next/eslint-plugin-next@npm:13.2.4"
@@ -3591,9 +3598,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-darwin-arm64@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-darwin-arm64@npm:14.0.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-x64@npm:14.0.0":
   version: 14.0.0
   resolution: "@next/swc-darwin-x64@npm:14.0.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-x64@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-darwin-x64@npm:14.0.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -3605,9 +3626,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-arm64-gnu@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-linux-arm64-gnu@npm:14.0.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-arm64-musl@npm:14.0.0":
   version: 14.0.0
   resolution: "@next/swc-linux-arm64-musl@npm:14.0.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-musl@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-linux-arm64-musl@npm:14.0.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
@@ -3619,9 +3654,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-x64-gnu@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-linux-x64-gnu@npm:14.0.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-x64-musl@npm:14.0.0":
   version: 14.0.0
   resolution: "@next/swc-linux-x64-musl@npm:14.0.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-musl@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-linux-x64-musl@npm:14.0.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -3633,6 +3682,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-win32-arm64-msvc@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-win32-arm64-msvc@npm:14.0.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-win32-ia32-msvc@npm:14.0.0":
   version: 14.0.0
   resolution: "@next/swc-win32-ia32-msvc@npm:14.0.0"
@@ -3640,9 +3696,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-win32-ia32-msvc@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-win32-ia32-msvc@npm:14.0.4"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@next/swc-win32-x64-msvc@npm:14.0.0":
   version: 14.0.0
   resolution: "@next/swc-win32-x64-msvc@npm:14.0.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:14.0.4":
+  version: 14.0.4
+  resolution: "@next/swc-win32-x64-msvc@npm:14.0.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7737,7 +7807,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -8159,9 +8229,10 @@ __metadata:
     "@types/react-dom": "npm:18.2.6"
     graphql: "npm:^16.7.1"
     graphql-tag: "npm:^2.12.6"
-    next: "npm:^14.0.0"
+    next: "npm:^14.0.4"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
+    ssr-only-secrets: "npm:^0.0.5"
     typescript: "npm:5.1.3"
   languageName: unknown
   linkType: soft
@@ -9366,6 +9437,62 @@ __metadata:
   bin:
     next: dist/bin/next
   checksum: 9db732496c40cb9de3d7d42031c6c392ca821bb3385afce059fbccffefcd04e49f610a099720c05459db846990e11085fe9dfad1356eb0dc3d62d8c2b30c8973
+  languageName: node
+  linkType: hard
+
+"next@npm:^14.0.4":
+  version: 14.0.4
+  resolution: "next@npm:14.0.4"
+  dependencies:
+    "@next/env": "npm:14.0.4"
+    "@next/swc-darwin-arm64": "npm:14.0.4"
+    "@next/swc-darwin-x64": "npm:14.0.4"
+    "@next/swc-linux-arm64-gnu": "npm:14.0.4"
+    "@next/swc-linux-arm64-musl": "npm:14.0.4"
+    "@next/swc-linux-x64-gnu": "npm:14.0.4"
+    "@next/swc-linux-x64-musl": "npm:14.0.4"
+    "@next/swc-win32-arm64-msvc": "npm:14.0.4"
+    "@next/swc-win32-ia32-msvc": "npm:14.0.4"
+    "@next/swc-win32-x64-msvc": "npm:14.0.4"
+    "@swc/helpers": "npm:0.5.2"
+    busboy: "npm:1.6.0"
+    caniuse-lite: "npm:^1.0.30001406"
+    graceful-fs: "npm:^4.2.11"
+    postcss: "npm:8.4.31"
+    styled-jsx: "npm:5.1.1"
+    watchpack: "npm:2.4.0"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    react: ^18.2.0
+    react-dom: ^18.2.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-ia32-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: f119dfed59ba14972759bbc354fd2e99793c5a31689465a5e7cacd329977ed3d259eb756142bef31e96f28a80a00997e76314425faeda4c6fcf4e4ad6c5fa960
   languageName: node
   linkType: hard
 
@@ -11027,6 +11154,17 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.3"
   checksum: 64f53d930f63c5a9e59d4cae487c1ffa87d25eab682833b01d572cc885e7e3fdbad4f03409a41f03ecb27f1f8959432253eb48332c7007c3388efddb24ba2792
+  languageName: node
+  linkType: hard
+
+"ssr-only-secrets@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "ssr-only-secrets@npm:0.0.5"
+  dependencies:
+    optimism: "npm:^0.17.5"
+  peerDependencies:
+    react: ^18
+  checksum: 692018b5652246c2c488bf364e134a3be54e17576e563e4c19385a25c51029d1cdb802656ab707f991db65282c7ee9f1f8bdddd4a7d0ec9c87ed0f3c7d9b27aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rehydration currently does not work in an app with a CSP that disables unsafe-inline scripts.

With this change, you can now follow the [NextJS guide](https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy) on CSP, and in `layout.tsx` or `page.tsx` pass the `nonce` from headers down into the `ApolloWrapper` to prevent `unsafe-inline` CSP errors.