### PR TITLE
reduce bundle size by adjusting imports

### DIFF
--- a/package/.eslintrc.js
+++ b/package/.eslintrc.js
@@ -26,5 +26,13 @@ module.exports = {
         varsIgnorePattern: "^_",
       },
     ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        prefer: "type-imports",
+        disallowTypeAnnotations: false,
+        fixStyle: "separate-type-imports",
+      },
+    ],
   },
 };

--- a/package/src/ssr/AccumulateMultipartResponsesLink.test.ts
+++ b/package/src/ssr/AccumulateMultipartResponsesLink.test.ts
@@ -1,17 +1,18 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import type {
+  ExecutionPatchResult,
+  FetchResult} from "@apollo/client";
 import {
   ApolloLink,
-  ExecutionPatchResult,
-  FetchResult,
   Observable,
   gql,
 } from "@apollo/client";
 import { AccumulateMultipartResponsesLink } from "./AccumulateMultipartResponsesLink";
 import { test, expect, assert, beforeEach, afterEach, vi } from "vitest";
 import { fromPartial } from "@total-typescript/shoehorn";
-import { SubscriptionObserver } from "zen-observable-ts";
+import type { SubscriptionObserver } from "zen-observable-ts";
 
 beforeEach(() => {
   vi.useFakeTimers();

--- a/package/src/ssr/AccumulateMultipartResponsesLink.ts
+++ b/package/src/ssr/AccumulateMultipartResponsesLink.ts
@@ -1,4 +1,5 @@
-import { ApolloLink, Operation, NextLink, FetchResult } from "@apollo/client";
+import type { Operation, NextLink, FetchResult } from "@apollo/client";
+import { ApolloLink } from "@apollo/client";
 import {
   Observable,
   hasDirectives,

--- a/package/src/ssr/ApolloNextAppProvider.tsx
+++ b/package/src/ssr/ApolloNextAppProvider.tsx
@@ -1,7 +1,8 @@
 "use client";
 import * as React from "react";
+import type {
+  ApolloClient} from "@apollo/client";
 import {
-  ApolloClient,
   ApolloProvider as _ApolloProvider,
 } from "@apollo/client";
 import { RehydrationContextProvider } from "./RehydrationContext";

--- a/package/src/ssr/ApolloNextAppProvider.tsx
+++ b/package/src/ssr/ApolloNextAppProvider.tsx
@@ -5,8 +5,9 @@ import type {
 import {
   ApolloProvider as _ApolloProvider,
 } from "@apollo/client";
+import type {
+  HydrationContextOptions} from "./RehydrationContext";
 import {
-  HydrationContextOptions,
   RehydrationContextProvider,
 } from "./RehydrationContext";
 

--- a/package/src/ssr/ApolloRehydrateSymbols.tsx
+++ b/package/src/ssr/ApolloRehydrateSymbols.tsx
@@ -1,5 +1,5 @@
-import { SuperJSONResult } from "superjson/dist/types";
-import {
+import type { SuperJSONResult } from "superjson/dist/types";
+import type {
   RehydrationCache,
   ResultsCache,
   BackgroundQueriesCache,

--- a/package/src/ssr/NextSSRApolloClient.tsx
+++ b/package/src/ssr/NextSSRApolloClient.tsx
@@ -9,7 +9,7 @@ import {
   Observable
 } from "@apollo/client";
 import type { QueryManager } from "@apollo/client/core/QueryManager";
-import { print } from "graphql";
+import { print } from "@apollo/client/utilities";
 import { canonicalStringify } from "@apollo/client/cache";
 import type { RehydrationContextValue } from "./types";
 import { registerLateInitializingQueue } from "./lateInitializingQueue";

--- a/package/src/ssr/NextSSRApolloClient.tsx
+++ b/package/src/ssr/NextSSRApolloClient.tsx
@@ -1,16 +1,17 @@
-import {
-  ApolloClient,
+import type {
   ApolloClientOptions,
   OperationVariables,
   WatchQueryOptions,
-  Observable,
   FetchResult,
-  DocumentNode,
+  DocumentNode} from "@apollo/client";
+import {
+  ApolloClient,
+  Observable
 } from "@apollo/client";
 import type { QueryManager } from "@apollo/client/core/QueryManager";
 import { print } from "graphql";
 import { canonicalStringify } from "@apollo/client/cache";
-import { RehydrationContextValue } from "./types";
+import type { RehydrationContextValue } from "./types";
 import { registerLateInitializingQueue } from "./lateInitializingQueue";
 import {
   ApolloBackgroundQueryTransport,

--- a/package/src/ssr/NextSSRInMemoryCache.tsx
+++ b/package/src/ssr/NextSSRInMemoryCache.tsx
@@ -1,10 +1,11 @@
-import {
-  InMemoryCache,
+import type {
   InMemoryCacheConfig,
   Cache,
-  Reference,
+  Reference} from "@apollo/client";
+import {
+  InMemoryCache
 } from "@apollo/client";
-import { RehydrationContextValue } from "./types";
+import type { RehydrationContextValue } from "./types";
 
 export class NextSSRInMemoryCache extends InMemoryCache {
   private rehydrationContext: Pick<

--- a/package/src/ssr/RehydrationContext.tsx
+++ b/package/src/ssr/RehydrationContext.tsx
@@ -2,7 +2,7 @@ import { useApolloClient } from "@apollo/client";
 import React from "react";
 import { NextSSRInMemoryCache } from "./NextSSRInMemoryCache";
 import { ServerInsertedHTMLContext } from "next/navigation";
-import { RehydrationContextValue } from "./types";
+import type { RehydrationContextValue } from "./types";
 import { registerDataTransport, transportDataToJS } from "./dataTransport";
 import invariant from "ts-invariant";
 import { NextSSRApolloClient } from "./NextSSRApolloClient";

--- a/package/src/ssr/RemoveMultipartDirectivesLink.test.ts
+++ b/package/src/ssr/RemoveMultipartDirectivesLink.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { RemoveMultipartDirectivesLink } from "./RemoveMultipartDirectivesLink";
 import { fromPartial } from "@total-typescript/shoehorn";
-import { gql, DocumentNode, Observable } from "@apollo/client";
+import type { DocumentNode} from "@apollo/client";
+import { gql, Observable } from "@apollo/client";
 import { print } from "graphql";
 import { it, expect } from "vitest";
 

--- a/package/src/ssr/RemoveMultipartDirectivesLink.ts
+++ b/package/src/ssr/RemoveMultipartDirectivesLink.ts
@@ -1,10 +1,12 @@
-import { ApolloLink, Operation, NextLink, DocumentNode } from "@apollo/client";
+import type { Operation, NextLink, DocumentNode } from "@apollo/client";
+import { ApolloLink } from "@apollo/client";
+import type {
+  RemoveDirectiveConfig} from "@apollo/client/utilities";
 import {
   Observable,
-  RemoveDirectiveConfig,
   removeDirectivesFromDocument,
 } from "@apollo/client/utilities";
-import { DirectiveNode } from "graphql";
+import type { DirectiveNode } from "graphql";
 
 interface RemoveMultipartDirectivesConfig {
   /**

--- a/package/src/ssr/dataTransport.ts
+++ b/package/src/ssr/dataTransport.ts
@@ -5,9 +5,9 @@ import {
   ApolloResultCache,
   ApolloBackgroundQueryTransport,
 } from "./ApolloRehydrateSymbols";
-import { RehydrationCache } from "./types";
+import type { RehydrationCache } from "./types";
 import { registerLateInitializingQueue } from "./lateInitializingQueue";
-import { Cache, WatchQueryOptions } from "@apollo/client";
+import type { Cache, WatchQueryOptions } from "@apollo/client";
 import invariant from "ts-invariant";
 
 export type DataTransport<T> = Array<T> | { push(...args: T[]): void };

--- a/package/src/ssr/types.tsx
+++ b/package/src/ssr/types.tsx
@@ -1,6 +1,6 @@
-import { Cache, WatchQueryOptions } from "@apollo/client";
-import React from "react";
-import { DataTransport } from "./dataTransport";
+import type { Cache, WatchQueryOptions } from "@apollo/client";
+import type React from "react";
+import type { DataTransport } from "./dataTransport";
 
 export type RehydrationCache = Record<string, unknown>;
 export type ResultsCache = DataTransport<Cache.WriteOptions>;


### PR DESCRIPTION
This should especially tree-shake a large part of the `graphql` package that showed up in https://github.com/apollographql/apollo-client-nextjs/issues/126#issuecomment-1875590159