### PR TITLE
Drop workarounds to work with both Apollo Client 3.8 and 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["latest", "next", "0.0.0-pr-11345-20231129164802"]
+        version: ["latest", "next"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apollo/experimental-nextjs-app-support",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "repository": {
     "url": "git+https://github.com/apollographql/apollo-client-nextjs"
   },
@@ -62,7 +62,7 @@
     "vitest": "1.2.1"
   },
   "peerDependencies": {
-    "@apollo/client": ">=3.8.0-rc || ^3.8.0 || >=3.9.0-alpha || >=3.9.0-beta || >=3.9.0-rc || ^3.9.0",
+    "@apollo/client": "^3.9.0",
     "next": "^13.4.1 || ^14.0.0",
     "react": "^18"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,7 +100,7 @@ __metadata:
     typescript: "npm:5.3.3"
     vitest: "npm:1.2.1"
   peerDependencies:
-    "@apollo/client": ">=3.8.0-rc || ^3.8.0 || >=3.9.0-alpha || >=3.9.0-beta || >=3.9.0-rc || ^3.9.0"
+    "@apollo/client": ^3.9.0
     next: ^13.4.1 || ^14.0.0
     react: ^18
   languageName: unknown


### PR DESCRIPTION
This PR drops the workarounds for this package to work with both AC 3.8 and 3.9 and bumps the minimum `peerDependency` version to 3.9.