### PR TITLE
Removing confusing installation language in README.md

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -33,7 +33,7 @@ This package provides the tools necessary to execute your GraphQL queries on the
 
 ## Installation
 
-This package has a peer dependency on the latest rc of `@apollo/client`, so you can install both this package and that Apollo Client version via
+This package has a peer dependency on the latest `@apollo/client`, so you can install both this package and that Apollo Client version via
 
 ```sh
 npm install @apollo/client@latest @apollo/experimental-nextjs-app-support


### PR DESCRIPTION
Removed unnecessary mention of the rc version of the @apollo/client package. This should remove confusion around which version should be installed. See https://github.com/apollographql/apollo-client-nextjs/releases/tag/v.0.8.0