### PR TITLE
add parameter type support to getClient

### DIFF
--- a/package/src/rsc/registerApolloClient.tsx
+++ b/package/src/rsc/registerApolloClient.tsx
@@ -3,7 +3,7 @@ import "server-only";
 import type { ApolloClient } from "@apollo/client";
 import * as React from "react";
 
-export function registerApolloClient(makeClient: () => ApolloClient<any>) {
+export function registerApolloClient<T extends any[]>(makeClient: (...args: T) => ApolloClient<any>) {
   const getClient = React.cache(makeClient);
   return {
     getClient,


### PR DESCRIPTION
I kept getting `getClient Expected 0 arguments, but got ...` because makeClient has no parameters