### PR TITLE
[idea] ensure that wrapped hooks are called instead of their upstream counterparts

### DIFF
--- a/examples/polls-demo/app/cc/poll-cc.tsx
+++ b/examples/polls-demo/app/cc/poll-cc.tsx
@@ -1,11 +1,8 @@
 "use client";
 import { Suspense } from "react";
-import {
-  useReadQuery,
-  useBackgroundQuery,
-} from "@apollo/experimental-nextjs-app-support/ssr";
+import { useReadQuery, useBackgroundQuery } from "@apollo/client";
 import { useMutation } from "@apollo/client";
-import { QueryReference } from "@apollo/client/react/cache/QueryReference";
+import { QueryReference } from "@apollo/client/react";
 import { Poll as PollInner } from "@/components/poll";
 
 import { useState, useCallback } from "react";

--- a/packages/client-react-streaming/src/DataTransportAbstraction/ensureNotCalledFromUnwrappedHook.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/ensureNotCalledFromUnwrappedHook.tsx
@@ -1,0 +1,38 @@
+import { cacheSlot } from "@apollo/client/cache/index.js";
+
+const hookRegex = /use((Background|Suspense|Read|)Query|Fragment)/;
+declare module globalThis {
+  const __DEV__: boolean | undefined;
+}
+
+// reuse the constructor of `cacheSlot` so we don't need to add a dependency on `optimism`.
+export const hookSlot =
+  new (cacheSlot.constructor as typeof import("optimism").Slot)<boolean>();
+
+export function ensureNotCalledFromUnwrappedHook() {
+  if (globalThis.__DEV__ !== false) {
+    // was called from a correct hook - we don't need any more checks
+    if (hookSlot.getValue() === true) return;
+    // otherwise, it could be called from a hook or from userland.
+    // we only want to warn on hooks code, so we need to detect a call from a hook
+    // this will only work in non-minified code (development?) by looking at the stack trace.
+    try {
+      throw new Error();
+    } catch (e) {
+      const match = hookRegex.exec((e as Error).stack || "");
+      if (match) {
+        try {
+          throw new Error();
+        } catch (e) {
+          console.warn(
+            `
+          You are using the hook ${match[0]} directly from the \`@apollo/client\` package.
+          Please use the corresponding hook from <pkgname> instead.
+          `, // we still need some way of communicating the right package name here
+            e
+          );
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This would work with `useFragment`, `useQuery`, `useSuspenseQuery` and `useBackgroundQuery` since all of those call either `watchQuery` or `watch`, and we can overwrite these.

It does not work with `useReadQuery` - @jerelmiller do you have an idea how we could make it work there?