### PR TITLE
[idea] wrap upstream package hooks with streaming functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   ],
   "dependencies": {
     "prettier": "^3.0.0"
+  },
+  "resolutions": {
+    "@apollo/client": "0.0.0-pr-11615-20240222131615"
   }
 }

--- a/packages/client-react-streaming/src/DataTransportAbstraction/hooks.ts
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/hooks.ts
@@ -1,43 +1,68 @@
 "use client";
+import type { ApolloClient } from "@apollo/client/index.js";
 import {
-  useFragment as orig_useFragment,
-  useSuspenseQuery as orig_useSuspenseQuery,
-  useReadQuery as orig_useReadQuery,
-  useQuery as orig_useQuery,
-  useBackgroundQuery as orig_useBackgroundQuery,
+  useApolloClient,
+  useFragment,
+  useSuspenseQuery,
+  useReadQuery,
+  useQuery,
+  useBackgroundQuery,
 } from "@apollo/client/index.js";
+import { wrapFunction } from "@apollo/client/utilities/internal/index.js";
 import { useTransportValue } from "./useTransportValue.js";
+import { WrappedApolloClient } from "./WrappedApolloClient.js";
 
-export const useFragment = wrap(orig_useFragment, [
-  "data",
-  "complete",
-  "missing",
-]);
-export const useQuery = wrap<typeof orig_useQuery>(
+export {
+  useFragment,
+  useSuspenseQuery,
+  useReadQuery,
+  useQuery,
+  useBackgroundQuery,
+};
+
+wrap(
+  useFragment,
+  ["data", "complete", "missing"],
+  (options) => options?.client
+);
+wrap<typeof useQuery>(
   process.env.REACT_ENV === "ssr"
     ? (query, options) =>
-        orig_useQuery(query, { ...options, fetchPolicy: "cache-only" })
-    : orig_useQuery,
-  ["data", "loading", "networkStatus", "called"]
+        useQuery(query, { ...options, fetchPolicy: "cache-only" })
+    : useQuery,
+  ["data", "loading", "networkStatus", "called"],
+  (_, options) => options?.client
 );
-export const useSuspenseQuery = wrap(orig_useSuspenseQuery, [
-  "data",
-  "networkStatus",
-]);
-export const useReadQuery = wrap(orig_useReadQuery, ["data", "networkStatus"]);
-
-export const useBackgroundQuery = orig_useBackgroundQuery;
+wrap(useSuspenseQuery, ["data", "networkStatus"], (_, options) =>
+  typeof options === "object" ? options.client : undefined
+);
+wrap(useReadQuery, ["data", "networkStatus"], () => undefined);
 
 function wrap<T extends (...args: any[]) => any>(
   useFn: T,
-  transportKeys: (keyof ReturnType<T>)[]
+  transportKeys: (keyof ReturnType<T>)[],
+  getClientFromArgs: (...args: Parameters<T>) => ApolloClient<any> | undefined
 ): T {
-  return ((...args: any[]) => {
-    const result = useFn(...args);
-    const transported: Partial<typeof result> = {};
-    for (const key of transportKeys) {
-      transported[key] = result[key];
-    }
-    return { ...result, ...useTransportValue(transported) };
-  }) as T;
+  return wrapFunction(
+    useFn,
+    (useFn) =>
+      ((...args: Parameters<T>) => {
+        let client;
+        try {
+          client = useApolloClient(getClientFromArgs(...args));
+        } catch {
+          /** nothing to do */
+        }
+        if (client && client instanceof WrappedApolloClient) {
+          const result = useFn(...args);
+          const transported: Partial<typeof result> = {};
+          for (const key of transportKeys) {
+            transported[key] = result[key];
+          }
+          return { ...result, ...useTransportValue(transported) };
+        }
+        // if this is called with a non-wrapped client (maybe in a test?), just call the original hook
+        return useFn(...args);
+      }) as T
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,9 +83,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@apollo/client@npm:3.9.1, @apollo/client@npm:^3.9.1":
-  version: 3.9.1
-  resolution: "@apollo/client@npm:3.9.1"
+"@apollo/client@npm:0.0.0-pr-11615-20240222131615":
+  version: 0.0.0-pr-11615-20240222131615
+  resolution: "@apollo/client@npm:0.0.0-pr-11615-20240222131615"
   dependencies:
     "@graphql-typed-document-node/core": "npm:^3.1.1"
     "@wry/caches": "npm:^1.0.0"
@@ -95,7 +95,7 @@ __metadata:
     hoist-non-react-statics: "npm:^3.3.2"
     optimism: "npm:^0.18.0"
     prop-types: "npm:^15.7.2"
-    rehackt: "npm:0.0.3"
+    rehackt: "npm:0.0.5"
     response-iterator: "npm:^0.2.6"
     symbol-observable: "npm:^4.0.0"
     ts-invariant: "npm:^0.10.3"
@@ -116,7 +116,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: 10/76c7024fbb7bd4a8e4cb1a36193c0ca23340b78e3a47006af6d91bd250b91006d8334856ac91c235d040bcaaadc0ef6d6eb0bba6a4f48b7fa12174f029e9eee1
+  checksum: 10/a13cc48a2fbb647fd3cff92094354897ff831b6e16af60f213613e76a904bfbe89c17964440b7d1093c43b0364b82a859f15573f9228eed067c4cf5d9491a40c
   languageName: node
   linkType: hard
 
@@ -12272,9 +12272,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rehackt@npm:0.0.3":
-  version: 0.0.3
-  resolution: "rehackt@npm:0.0.3"
+"rehackt@npm:0.0.5":
+  version: 0.0.5
+  resolution: "rehackt@npm:0.0.5"
   peerDependencies:
     "@types/react": "*"
     react: "*"
@@ -12283,7 +12283,7 @@ __metadata:
       optional: true
     react:
       optional: true
-  checksum: 10/2e3674d84aca46802f38cf5b01c62bf7d0ca5e324b2749dd79156fa61723e9f84df7778c39f97d351e815a852a8a8ac9633e29b6b7b8734d18042fda86620f54
+  checksum: 10/a7536eaeb47ba46bc29fa050c7cbf80860809689c893c6177664efbbdca641a1996185ea6602fb76473f0e2b145c1f3e9c27a5e738054d69809b6c39046fe269
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This, in combination with https://github.com/apollographql/apollo-client/pull/11615 would make it possible to inject functionality into the `@apollo/client` hooks, so it wouldn't matter if users used the `@apollo/client` hooks, or the hooks from this package.

That has one clear downside, though: 
This is a side effect that pulls all the hooks into the bundle - tree shaking of the hooks would become impossible. 

It might very well be worth it, though 🤔 

As an alternative, we could export `set up` functions for all the hooks and introduce people to execute those set up functions, which would circumvent that, but creates more friction.