### PR TITLE
[experiment/idea] allow enabling "forced suspense" for useQuery hook in SSR

### DIFF
--- a/integration-test/nextjs/src/app/cc/dynamic/useQuery_forcedSuspense/page.tsx
+++ b/integration-test/nextjs/src/app/cc/dynamic/useQuery_forcedSuspense/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useQuery } from "@apollo/experimental-nextjs-app-support/ssr";
+import { enableSSRWaitForUseQuery } from "@apollo/client-react-streaming";
+import type { TypedDocumentNode } from "@apollo/client";
+import { gql, useApolloClient } from "@apollo/client";
+
+const QUERY: TypedDocumentNode<{
+  products: {
+    id: string;
+    title: string;
+  }[];
+}> = gql`
+  query dynamicProducts {
+    products {
+      id
+      title
+    }
+  }
+`;
+
+export const dynamic = "force-dynamic";
+
+export default function Page() {
+  enableSSRWaitForUseQuery(useApolloClient());
+  const result = useQuery(QUERY);
+  globalThis.hydrationFinished?.();
+
+  if (!result.data) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <ul>
+      {result.data.products.map(({ id, title }) => (
+        <li key={id}>{title}</li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.tsx
@@ -24,7 +24,7 @@ import type {
   TransportIdentifier,
 } from "./DataTransportAbstraction.js";
 
-function getQueryManager<TCacheShape>(
+export function getQueryManager<TCacheShape>(
   client: OrigApolloClient<unknown>
 ): QueryManager<TCacheShape> & {
   [wrappers]: HookWrappers;
@@ -38,7 +38,7 @@ type SimulatedQueryInfo = {
   options: WatchQueryOptions<OperationVariables, any>;
 };
 
-const wrappers = Symbol.for("apollo.hook.wrappers");
+export const wrappers = Symbol.for("apollo.hook.wrappers");
 class ApolloClientBase<TCacheShape> extends OrigApolloClient<TCacheShape> {
   constructor(options: ApolloClientOptions<TCacheShape>) {
     super(options);

--- a/packages/client-react-streaming/src/DataTransportAbstraction/hooks.ts
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/hooks.ts
@@ -1,5 +1,15 @@
 import type { HookWrappers } from "@apollo/client/react/internal/index.js";
 import { useTransportValue } from "./useTransportValue.js";
+import type { WatchQueryOptions } from "@apollo/client";
+import { useApolloClient } from "@apollo/client";
+import { getSuspenseCache } from "@apollo/client/react/internal";
+import { canonicalStringify } from "@apollo/client/cache";
+import { use } from "react";
+import {
+  ApolloClient,
+  getQueryManager,
+  wrappers,
+} from "./WrappedApolloClient.js";
 
 export const hookWrappers: HookWrappers = {
   useFragment(orig_useFragment) {
@@ -35,3 +45,38 @@ function wrap<T extends (...args: any[]) => any>(
     return { ...result, ...useTransportValue(transported) };
   }) as T;
 }
+
+export const enableSSRWaitForUseQuery: (client: ApolloClient<any>) => void =
+  process.env.REACT_ENV === "ssr"
+    ? (client) => {
+        getQueryManager(client)[wrappers].useQuery = (orig_useQuery) =>
+          wrap<typeof orig_useQuery>(
+            function useQuery(query, options) {
+              const client = useApolloClient();
+              const result = client.cache.read({
+                query,
+                variables: options?.variables,
+                returnPartialData: options?.returnPartialData,
+                optimistic: false,
+              });
+              if (!result) {
+                const queryRef = getSuspenseCache(client).getQueryRef(
+                  [query, canonicalStringify(options?.variables), "useQuery"],
+                  () =>
+                    client.watchQuery({
+                      query,
+                      ...(options as Partial<WatchQueryOptions>),
+                    })
+                );
+                use(queryRef.promise);
+              }
+
+              return orig_useQuery(query, {
+                ...options,
+                fetchPolicy: "cache-only",
+              });
+            },
+            ["data", "loading", "networkStatus", "called"]
+          );
+      }
+    : () => {};

--- a/packages/client-react-streaming/src/DataTransportAbstraction/index.ts
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/index.ts
@@ -9,3 +9,4 @@ export type {
   QueryEvent,
 } from "./DataTransportAbstraction.js";
 export { WrapApolloProvider } from "./WrapApolloProvider.js";
+export { enableSSRWaitForUseQuery } from "./hooks.js";

--- a/packages/client-react-streaming/src/index.ts
+++ b/packages/client-react-streaming/src/index.ts
@@ -5,4 +5,5 @@ export {
   DataTransportProviderImplementation,
   QueryEvent,
   WrapApolloProvider,
+  enableSSRWaitForUseQuery,
 } from "./DataTransportAbstraction/index.js";


### PR DESCRIPTION
This came up in https://community.apollographql.com/t/streaming-without-suspense-in-apollo-nextjs-client/7259 - essentially, we could allow users to opt `useQuery` into suspending during SSR, so `useQuery` result could also be streamed from SSR instead of just rendering a "loading" indicator in SSR.

If we actually want to do this, it should probably be documented as a "you can do this while you are migrating to suspense" approach.