### PR TITLE
Update README.md

### DIFF
--- a/packages/experimental-nextjs-app-support/README.md
+++ b/packages/experimental-nextjs-app-support/README.md
@@ -70,7 +70,7 @@ export const { getClient } = registerApolloClient(() => {
 You can then use that `getClient` function in your server components:
 
 ```js
-const { data } = await getClient().query({ query: userQuery });
+const { data } = await getClient().query({ query: useQuery });
 ```
 
 ### In SSR


### PR DESCRIPTION
Simply fixing and ensuring users are not ambiguous when seeing `userQuery` while what is defined above it is `useQuery`.