### PR TITLE
0.10.0 (4) default `connectToDevTools` to `false` in RSC and SSR builds

### DIFF
--- a/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.test.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.test.tsx
@@ -108,7 +108,6 @@ describe(
 
         const link = new MockSubscriptionLink();
         const client = new ApolloClient({
-          connectToDevTools: false,
           cache: new InMemoryCache(),
           link,
         });

--- a/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.tsx
@@ -49,7 +49,14 @@ class ApolloClientBase<TCacheShape> extends OrigApolloClient<TCacheShape> {
   static readonly info = bundle;
 
   constructor(options: ApolloClientOptions<TCacheShape>) {
-    super(options);
+    super(
+      process.env.REACT_ENV === "rsc" || process.env.REACT_ENV === "ssr"
+        ? {
+            connectToDevTools: false,
+            ...options,
+          }
+        : options
+    );
 
     if (!(this.cache instanceof InMemoryCache)) {
       throw new Error(

--- a/packages/client-react-streaming/src/importErrors.test.tsx
+++ b/packages/client-react-streaming/src/importErrors.test.tsx
@@ -37,7 +37,6 @@ test(
               // @ts-expect-error we want to test exactly this
               new upstreamPkg.ApolloClient({
                 cache: new upstreamPkg.InMemoryCache(),
-                connectToDevTools: false,
               }),
             children: null,
           })

--- a/packages/client-react-streaming/src/registerApolloClient.test.tsx
+++ b/packages/client-react-streaming/src/registerApolloClient.test.tsx
@@ -53,7 +53,6 @@ function drain(stream: ReturnType<typeof renderToPipeableStream>) {
 function makeClient() {
   return new ApolloClient({
     cache: new InMemoryCache(),
-    connectToDevTools: false,
   });
 }
 


### PR DESCRIPTION
closes #238

The last PR for 0.10.0.

This defaults `connectToDevTools` to `false` in RSC and SSR builds where connecting to the DevTools is impossible anyways, but might end up in a stray `setTimeout` that hangs around for 10 seconds which uses memory unneccessarily - and e.g. prevents tests from cleaning up correctly.

No tests for this since I'm not sure how correctly to test this - but I could remove a few `connectToDevTools` from our tests, which is nice. I looked at the built artefacts though, and it's picked up correctly.