### PR TITLE
remove superjson dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,6 @@
   ignoreDeps: [
     "react",
     "react-dom",
-    "superjson",
     "@apollo/experimental-nextjs-app-support",
     "@apollo/client-react-streaming",
     "@apollo/client",

--- a/integration-test/yarn.lock
+++ b/integration-test/yarn.lock
@@ -32,13 +32,12 @@ __metadata:
   linkType: hard
 
 "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs::locator=%40integration-test%2Froot%40workspace%3A.":
-  version: 0.8.0
+  version: 0.10.0
   resolution: "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs#./shared/build-client-react-streaming.cjs::hash=48b117&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
-    superjson: "npm:^1.12.2 || ^2.0.0"
     ts-invariant: "npm:^0.10.3"
   peerDependencies:
-    "@apollo/client": ^3.9.0
+    "@apollo/client": ^3.9.6
     react: ^18
   checksum: 10/8e12155ebcb9672f5b645c364d356018014df750412c61613341121ebb4d4eabb5f42cd9018cc3a81ad988f1b425548d68254ca49ede19c31d0d9e5a9a4f240a
   languageName: node
@@ -82,12 +81,12 @@ __metadata:
   linkType: hard
 
 "@apollo/experimental-nextjs-app-support@exec:./shared/build-experimental-nextjs-app-support.cjs::locator=%40integration-test%2Froot%40workspace%3A.":
-  version: 0.8.0
+  version: 0.10.0
   resolution: "@apollo/experimental-nextjs-app-support@exec:./shared/build-experimental-nextjs-app-support.cjs#./shared/build-experimental-nextjs-app-support.cjs::hash=fd83cc&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
-    "@apollo/client-react-streaming": "npm:^0.9.0"
+    "@apollo/client-react-streaming": "npm:0.10.0"
   peerDependencies:
-    "@apollo/client": ^3.9.0
+    "@apollo/client": ^3.9.6
     next: ^13.4.1 || ^14.0.0
     react: ^18
   checksum: 10/505b723bac0f3a7f15287ea32fab9f2e8c0cd567149abf11d750855f8a9bfc0aa26e44179ad10c32f7d162ad86318717032413ef8e1a25385185178e022588fa
@@ -3973,15 +3972,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-anything@npm:^3.0.2":
-  version: 3.0.5
-  resolution: "copy-anything@npm:3.0.5"
-  dependencies:
-    is-what: "npm:^4.1.8"
-  checksum: 10/4c41385a94a1cff6352a954f9b1c05b6bb1b70713a2d31f4c7b188ae7187ce00ddcc9c09bd58d24cd35b67fc6dd84df5954c0be86ea10700ff74e677db3cb09c
-  languageName: node
-  linkType: hard
-
 "core-js-compat@npm:^3.31.0, core-js-compat@npm:^3.34.0":
   version: 3.36.0
   resolution: "core-js-compat@npm:3.36.0"
@@ -5402,13 +5392,6 @@ __metadata:
     call-bind: "npm:^1.0.2"
     get-intrinsic: "npm:^1.1.1"
   checksum: 10/8f2ddb9639716fd7936784e175ea1183c5c4c05274c34f34f6a53175313cb1c9c35a8b795623306995e2f7cc8f25aa46302f15a2113e51c5052d447be427195c
-  languageName: node
-  linkType: hard
-
-"is-what@npm:^4.1.8":
-  version: 4.1.16
-  resolution: "is-what@npm:4.1.16"
-  checksum: 10/f6400634bae77be6903365dc53817292e1c4d8db1b467515d0c842505b8388ee8e558326d5e6952cb2a9d74116eca2af0c6adb8aa7e9d5c845a130ce9328bf13
   languageName: node
   linkType: hard
 
@@ -7956,15 +7939,6 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 10/4f6a5d0010770fdeea1183d919d528fd46c484e23c0535ef3e1dd49488116f639c594f3bd4440e3bc8a8686c9f8d53c5761599870ff039ede11a5c3bfe08a4be
-  languageName: node
-  linkType: hard
-
-"superjson@npm:^1.12.2 || ^2.0.0":
-  version: 2.2.1
-  resolution: "superjson@npm:2.2.1"
-  dependencies:
-    copy-anything: "npm:^3.0.2"
-  checksum: 10/bb8743a87c97f7845e0c27af1af0731d3185b32099ebce2aee0e67ac9a6ae9a7c4b9edfca7e1fe48693a78b56d5922d1cd13ef80c2fa12b788d3fc0ca25afe47
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "resolutions": {
     "react@18.2.0": "18.3.0-canary-60a927d04-20240113",
     "react-dom@18.2.0": "18.3.0-canary-60a927d04-20240113",
-    "superjson": "1.13.3",
     "@microsoft/api-documenter": "7.24.1"
   },
   "devDependencies": {

--- a/packages/client-react-streaming/package.json
+++ b/packages/client-react-streaming/package.json
@@ -136,7 +136,6 @@
     "react-error-boundary": "4.0.13",
     "react-server-dom-webpack": "18.3.0-canary-60a927d04-20240113",
     "rimraf": "5.0.5",
-    "superjson": "1.13.3",
     "ts-node": "10.9.2",
     "tsup": "8.0.2",
     "tsx": "4.7.1",
@@ -148,7 +147,6 @@
     "react": "^18"
   },
   "dependencies": {
-    "superjson": "^1.12.2 || ^2.0.0",
     "ts-invariant": "^0.10.3"
   }
 }

--- a/packages/client-react-streaming/src/ManualDataTransport/ApolloRehydrateSymbols.tsx
+++ b/packages/client-react-streaming/src/ManualDataTransport/ApolloRehydrateSymbols.tsx
@@ -1,8 +1,8 @@
-import type { DataTransport, JSONResult } from "./dataTransport.js";
+import type { DataTransport } from "./dataTransport.js";
 
 declare global {
   interface Window {
-    [ApolloSSRDataTransport]?: DataTransport<JSONResult>;
+    [ApolloSSRDataTransport]?: DataTransport<unknown>;
   }
 }
 export const ApolloSSRDataTransport = /*#__PURE__*/ Symbol.for(

--- a/packages/client-react-streaming/src/ManualDataTransport/ApolloRehydrateSymbols.tsx
+++ b/packages/client-react-streaming/src/ManualDataTransport/ApolloRehydrateSymbols.tsx
@@ -1,11 +1,8 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore depending on the superjson version, this might not be right
-import type { SuperJSONResult } from "superjson";
-import type { DataTransport } from "./dataTransport.js";
+import type { DataTransport, JSONResult } from "./dataTransport.js";
 
 declare global {
   interface Window {
-    [ApolloSSRDataTransport]?: DataTransport<SuperJSONResult>;
+    [ApolloSSRDataTransport]?: DataTransport<JSONResult>;
   }
 }
 export const ApolloSSRDataTransport = /*#__PURE__*/ Symbol.for(

--- a/packages/client-react-streaming/src/ManualDataTransport/ManualDataTransport.tsx
+++ b/packages/client-react-streaming/src/ManualDataTransport/ManualDataTransport.tsx
@@ -16,6 +16,7 @@ export interface ManualDataTransportOptions {
   /**
    * Prepare data for injecting into the stream by converting it into a string that can be parsed as JavaScript by the browser.
    * Could e.g. be `SuperJSON.stringify` or `serialize-javascript`.
+   * The default implementation act like a JSON.stringify that preserves `undefined`, but not do much on top of that.
    */
   stringifyForStream?: (value: any) => string;
   /**

--- a/packages/client-react-streaming/src/ManualDataTransport/RehydrationContext.tsx
+++ b/packages/client-react-streaming/src/ManualDataTransport/RehydrationContext.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { RehydrationContextValue } from "./types.js";
 import { transportDataToJS } from "./dataTransport.js";
 import { invariant } from "ts-invariant";
+import type { Stringify } from "./serialization.js";
 
 /**
  * @public
@@ -29,10 +30,12 @@ type ScriptProps = SerializableProps<
 >;
 
 export function buildApolloRehydrationContext({
-  extraScriptProps,
   insertHtml,
+  stringify,
+  extraScriptProps,
 }: HydrationContextOptions & {
   insertHtml: (callbacks: () => React.ReactNode) => void;
+  stringify: Stringify;
 }): RehydrationContextValue {
   function ensureInserted() {
     if (!rehydrationContext.currentlyInjected) {
@@ -59,15 +62,18 @@ export function buildApolloRehydrationContext({
       );
       invariant.debug("transporting events", rehydrationContext.incomingEvents);
 
-      const __html = transportDataToJS({
-        rehydrate: Object.fromEntries(
-          Object.entries(rehydrationContext.transportValueData).filter(
-            ([key, value]) =>
-              rehydrationContext.transportedValues[key] !== value
-          )
-        ),
-        events: rehydrationContext.incomingEvents,
-      });
+      const __html = transportDataToJS(
+        {
+          rehydrate: Object.fromEntries(
+            Object.entries(rehydrationContext.transportValueData).filter(
+              ([key, value]) =>
+                rehydrationContext.transportedValues[key] !== value
+            )
+          ),
+          events: rehydrationContext.incomingEvents,
+        },
+        stringify
+      );
       Object.assign(
         rehydrationContext.transportedValues,
         rehydrationContext.transportValueData

--- a/packages/client-react-streaming/src/ManualDataTransport/dataTransport.test.ts
+++ b/packages/client-react-streaming/src/ManualDataTransport/dataTransport.test.ts
@@ -1,0 +1,39 @@
+import test, { describe } from "node:test";
+import { revive, stringify } from "./dataTransport.js";
+import { outsideOf } from "../util/runInConditions.js";
+import { htmlEscapeJsonString } from "./htmlescape.js";
+import assert from "node:assert";
+
+describe(
+  "serialization and deserialization of data",
+  // we do not test the bundle, so we really just need to run this test in one environment
+  { skip: outsideOf("node") },
+  () => {
+    for (const [data, serialized] of [
+      [{ a: 1, b: 2, c: 3 }, '{"undefined":"$u","value":{"a":1,"b":2,"c":3}}'],
+      [
+        { a: "$u", b: 2, c: 3 },
+        '{"undefined":"$$u","value":{"a":"$u","b":2,"c":3}}',
+      ],
+      [
+        { a: "a$u", b: undefined, c: 3 },
+        '{"undefined":"$u","value":{"a":"a$u","b":"$u","c":3}}',
+      ],
+      [
+        { a: "$u", b: 2, c: undefined },
+        '{"undefined":"$$u","value":{"a":"$u","b":2,"c":"$$u"}}',
+      ],
+      [
+        { a: undefined, b: 2, c: 3 },
+        '{"undefined":"$u","value":{"a":"$u","b":2,"c":3}}',
+      ],
+    ]) {
+      test(JSON.stringify(data), () => {
+        const stringified = stringify(data);
+        const result = revive(eval(`(${htmlEscapeJsonString(stringified)})`));
+        assert.equal(stringified, serialized);
+        assert.deepStrictEqual(data, result);
+      });
+    }
+  }
+);

--- a/packages/client-react-streaming/src/ManualDataTransport/serialization.test.ts
+++ b/packages/client-react-streaming/src/ManualDataTransport/serialization.test.ts
@@ -12,22 +12,24 @@ describe(
     for (const [data, serialized] of [
       [{ a: 1, b: 2, c: 3 }, '{"undefined":"$u","value":{"a":1,"b":2,"c":3}}'],
       [
-        { a: "$u", b: 2, c: 3 },
-        '{"undefined":"$$u","value":{"a":"$u","b":2,"c":3}}',
+        { a: "$apollo.undefined$", b: 2, c: undefined },
+        '{"a":"$apollo.undefined$","b":2,"c":undefined}',
       ],
       [
-        { a: "a$u", b: undefined, c: 3 },
-        '{"undefined":"$u","value":{"a":"a$u","b":"$u","c":3}}',
+        { a: "a$apollo.undefined$", b: undefined, c: 3 },
+        '{"a":"a$apollo.undefined$","b":undefined,"c":3}',
       ],
       [
-        { a: "$u", b: 2, c: undefined },
-        '{"undefined":"$$u","value":{"a":"$u","b":2,"c":"$$u"}}',
+        {
+          a: "$$apollo.undefined$",
+          b: 2,
+          c: undefined,
+          d: "$apollo.undefined$",
+        },
+        '{"a":"$$apollo.undefined$","b":2,"c":undefined,"d":"$apollo.undefined$"}',
       ],
-      [
-        { a: undefined, b: 2, c: 3 },
-        '{"undefined":"$u","value":{"a":"$u","b":2,"c":3}}',
-      ],
-    ]) {
+      [{ a: undefined, b: 2, c: 3 }, '{"a":undefined,"b":2,"c":3}'],
+    ] as const) {
       test(JSON.stringify(data), () => {
         const stringified = stringify(data);
         const result = revive(eval(`(${htmlEscapeJsonString(stringified)})`));

--- a/packages/client-react-streaming/src/ManualDataTransport/serialization.test.ts
+++ b/packages/client-react-streaming/src/ManualDataTransport/serialization.test.ts
@@ -10,7 +10,7 @@ describe(
   { skip: outsideOf("node") },
   () => {
     for (const [data, serialized] of [
-      [{ a: 1, b: 2, c: 3 }, '{"undefined":"$u","value":{"a":1,"b":2,"c":3}}'],
+      [{ a: 1, b: 2, c: 3 }, '{"a":1,"b":2,"c":3}'],
       [
         { a: "$apollo.undefined$", b: 2, c: undefined },
         '{"a":"$apollo.undefined$","b":2,"c":undefined}',

--- a/packages/client-react-streaming/src/ManualDataTransport/serialization.test.ts
+++ b/packages/client-react-streaming/src/ManualDataTransport/serialization.test.ts
@@ -1,5 +1,5 @@
 import test, { describe } from "node:test";
-import { revive, stringify } from "./dataTransport.js";
+import { revive, stringify } from "./serialization.js";
 import { outsideOf } from "../util/runInConditions.js";
 import { htmlEscapeJsonString } from "./htmlescape.js";
 import assert from "node:assert";

--- a/packages/client-react-streaming/src/ManualDataTransport/serialization.ts
+++ b/packages/client-react-streaming/src/ManualDataTransport/serialization.ts
@@ -1,5 +1,5 @@
 /**
- * Stringifies a value to be injected into JavaScript "text" - preverves `undefined` values.
+ * Stringifies a value to be injected into JavaScript "text" - preserves `undefined` values.
  */
 export function stringify(value: any) {
   let undefinedPlaceholder = "$apollo.undefined$";

--- a/packages/client-react-streaming/src/ManualDataTransport/serialization.ts
+++ b/packages/client-react-streaming/src/ManualDataTransport/serialization.ts
@@ -1,0 +1,21 @@
+/**
+ * Stringifies a value to be injected into JavaScript "text" - preverves `undefined` values.
+ */
+export function stringify(value: any) {
+  let undefinedPlaceholder = "$apollo.undefined$";
+
+  const stringified = JSON.stringify(value);
+  while (stringified.includes(JSON.stringify(undefinedPlaceholder))) {
+    undefinedPlaceholder = "$" + undefinedPlaceholder;
+  }
+  return JSON.stringify(value, (_, v) =>
+    v === undefined ? undefinedPlaceholder : v
+  ).replaceAll(JSON.stringify(undefinedPlaceholder), "undefined");
+}
+
+export function revive(value: any): any {
+  return value;
+}
+
+export type Stringify = typeof stringify;
+export type Revive = typeof revive;

--- a/packages/client-react-streaming/tsup.config.ts
+++ b/packages/client-react-streaming/tsup.config.ts
@@ -16,12 +16,7 @@ export default defineConfig((options) => {
         }
       : false,
     outDir: "dist/",
-    external: [
-      "@apollo/client-react-streaming",
-      "react",
-      "rehackt",
-      "superjson",
-    ],
+    external: ["@apollo/client-react-streaming", "react", "rehackt"],
     noExternal: ["@apollo/client"], // will be handled by `acModuleImports`
     esbuildPlugins: [acModuleImports],
   };
@@ -45,8 +40,11 @@ export default defineConfig((options) => {
       },
       footer(ctx) {
         return {
-          js: ctx.format === 'esm' ? `export const built_for_${env} = true;` : `exports.built_for_${env} = true;`
-        }
+          js:
+            ctx.format === "esm"
+              ? `export const built_for_${env} = true;`
+              : `exports.built_for_${env} = true;`,
+        };
       },
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,7 +73,6 @@ __metadata:
     react-error-boundary: "npm:4.0.13"
     react-server-dom-webpack: "npm:18.3.0-canary-60a927d04-20240113"
     rimraf: "npm:5.0.5"
-    superjson: "npm:1.13.3"
     ts-invariant: "npm:^0.10.3"
     ts-node: "npm:10.9.2"
     tsup: "npm:8.0.2"
@@ -7316,15 +7315,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-anything@npm:^3.0.2":
-  version: 3.0.3
-  resolution: "copy-anything@npm:3.0.3"
-  dependencies:
-    is-what: "npm:^4.1.8"
-  checksum: 10/d376bfd5f657c96e9b0ef5e8709dcb52bc085c0af7b1c30c6c0337fa9ce56287bf0aaf4db13f9931b504ee5f6beb4494d9ca1b6e947a12995476ca288b3653c6
-  languageName: node
-  linkType: hard
-
 "copy-to-clipboard@npm:3.3.3":
   version: 3.3.3
   resolution: "copy-to-clipboard@npm:3.3.3"
@@ -10744,13 +10734,6 @@ __metadata:
     call-bind: "npm:^1.0.2"
     get-intrinsic: "npm:^1.1.1"
   checksum: 10/8f2ddb9639716fd7936784e175ea1183c5c4c05274c34f34f6a53175313cb1c9c35a8b795623306995e2f7cc8f25aa46302f15a2113e51c5052d447be427195c
-  languageName: node
-  linkType: hard
-
-"is-what@npm:^4.1.8":
-  version: 4.1.8
-  resolution: "is-what@npm:4.1.8"
-  checksum: 10/943eca6c1e64df487060857a4b6ac2e584b99e633a96e64c82bd49584a85d91f6f3e22d4a2d28c1243522152b261f50021db40a5ef7d98c754ebc7209c87b071
   languageName: node
   linkType: hard
 
@@ -14625,15 +14608,6 @@ __metadata:
     sucrase: bin/sucrase
     sucrase-node: bin/sucrase-node
   checksum: 10/3f18c8db09fee863fc930b64bad738d8710d7aa56ecf900849e159f12ead68c09565ae7d5cef8341123950a035e95ed4d0f8474418623fb702164f4853bab57f
-  languageName: node
-  linkType: hard
-
-"superjson@npm:1.13.3":
-  version: 1.13.3
-  resolution: "superjson@npm:1.13.3"
-  dependencies:
-    copy-anything: "npm:^3.0.2"
-  checksum: 10/71a186c513a9821e58264c0563cd1b3cf07d3b5ba53a09cc5c1a604d8ffeacac976a6ba1b5d5b3c71b6ab5a1941dfba5a15e3f106ad3ef22fe8d5eee3e2be052
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
closes #209

This is a big bundle size reduction for the library itself (see below, -44.93% on what we ship to the browser with the Next.js package), but beyond that it also cuts down a lot on data transported by the library, as SuperJSON adds a lot of extra bulk in their serialization format that we just don't need.

That said, some of our users might have non-serializable values in the cache and also want that transported over, so I'm leaving an escape hatch: `stringify` and `revive` can be configured.