### PR TITLE
Transport minified version of query.

### DIFF
--- a/integration-test/yarn.lock
+++ b/integration-test/yarn.lock
@@ -32,13 +32,13 @@ __metadata:
   linkType: hard
 
 "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs::locator=%40integration-test%2Froot%40workspace%3A.":
-  version: 0.8.0
+  version: 0.10.0
   resolution: "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs#./shared/build-client-react-streaming.cjs::hash=48b117&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
     superjson: "npm:^1.12.2 || ^2.0.0"
     ts-invariant: "npm:^0.10.3"
   peerDependencies:
-    "@apollo/client": ^3.9.0
+    "@apollo/client": ^3.9.6
     react: ^18
   checksum: 10/8e12155ebcb9672f5b645c364d356018014df750412c61613341121ebb4d4eabb5f42cd9018cc3a81ad988f1b425548d68254ca49ede19c31d0d9e5a9a4f240a
   languageName: node
@@ -82,12 +82,12 @@ __metadata:
   linkType: hard
 
 "@apollo/experimental-nextjs-app-support@exec:./shared/build-experimental-nextjs-app-support.cjs::locator=%40integration-test%2Froot%40workspace%3A.":
-  version: 0.8.0
+  version: 0.10.0
   resolution: "@apollo/experimental-nextjs-app-support@exec:./shared/build-experimental-nextjs-app-support.cjs#./shared/build-experimental-nextjs-app-support.cjs::hash=fd83cc&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
-    "@apollo/client-react-streaming": "npm:^0.9.0"
+    "@apollo/client-react-streaming": "npm:0.10.0"
   peerDependencies:
-    "@apollo/client": ^3.9.0
+    "@apollo/client": ^3.9.6
     next: ^13.4.1 || ^14.0.0
     react: ^18
   checksum: 10/505b723bac0f3a7f15287ea32fab9f2e8c0cd567149abf11d750855f8a9bfc0aa26e44179ad10c32f7d162ad86318717032413ef8e1a25385185178e022588fa

--- a/packages/client-react-streaming/src/DataTransportAbstraction/DataTransportAbstraction.ts
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/DataTransportAbstraction.ts
@@ -74,7 +74,7 @@ export type TransportIdentifier = string & { __transportIdentifier: true };
 export type QueryEvent =
   | {
       type: "started";
-      options: WatchQueryOptions;
+      options: { query: string } & Omit<WatchQueryOptions, "query">;
       id: TransportIdentifier;
     }
   | {

--- a/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.test.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.test.tsx
@@ -7,10 +7,7 @@ import type {
   TransportIdentifier,
 } from "./DataTransportAbstraction.js";
 
-import type {
-  TypedDocumentNode,
-  WatchQueryOptions,
-} from "@apollo/client/index.js";
+import type { TypedDocumentNode } from "@apollo/client/index.js";
 import { MockSubscriptionLink } from "@apollo/client/testing/core/mocking/mockSubscriptionLink.js";
 import {
   useSuspenseQuery,
@@ -18,6 +15,7 @@ import {
   DocumentTransform,
 } from "@apollo/client/index.js";
 import { visit, Kind, print, isDefinitionNode } from "graphql";
+import { printMinified } from "./printMinified.js";
 
 const {
   ApolloClient,
@@ -45,16 +43,15 @@ describe(
         me
       }
     `;
-    const FIRST_REQUEST: WatchQueryOptions = {
-      fetchPolicy: "cache-first",
-      nextFetchPolicy: undefined,
-      notifyOnNetworkStatusChange: false,
-      query: QUERY_ME,
-    };
     const EVENT_STARTED: QueryEvent = {
       type: "started",
       id: "1" as any,
-      options: FIRST_REQUEST,
+      options: {
+        fetchPolicy: "cache-first",
+        nextFetchPolicy: undefined,
+        notifyOnNetworkStatusChange: false,
+        query: printMinified(QUERY_ME),
+      },
     };
     const FIRST_RESULT = { me: "User" };
     const EVENT_DATA: QueryEvent = {
@@ -423,7 +420,7 @@ describe("document transforms are applied correctly", async () => {
         type: "started",
         id: "1" as TransportIdentifier,
         options: {
-          query: untransformedQuery,
+          query: printMinified(untransformedQuery),
         },
       });
       client.rerunSimulatedQueries!();
@@ -450,7 +447,7 @@ describe("document transforms are applied correctly", async () => {
         type: "started",
         id: "1" as TransportIdentifier,
         options: {
-          query: untransformedQuery,
+          query: printMinified(untransformedQuery),
         },
       });
       client.onQueryProgress!({

--- a/packages/client-react-streaming/src/DataTransportAbstraction/printMinified.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/printMinified.tsx
@@ -1,0 +1,15 @@
+import type { DocumentNode } from "@apollo/client/index.js";
+import { print } from "@apollo/client/utilities/index.js";
+
+export function printMinified(query: DocumentNode): string {
+  return (
+    print(query)
+      // replace multi-spaces with single space
+      .replace(/\s{2,}/g, " ")
+      // remove spaces that are preceeded by braces
+      .replace(/(?<=[{}])\s+/g, "")
+      // remove spaces that are preceeding braces
+      .replace(/\s+(?=[{}])/g, "")
+      .trim()
+  );
+}

--- a/packages/client-react-streaming/src/DataTransportAbstraction/printMinified.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/printMinified.tsx
@@ -1,15 +1,7 @@
 import type { DocumentNode } from "@apollo/client/index.js";
 import { print } from "@apollo/client/utilities/index.js";
+import { stripIgnoredCharacters } from "graphql";
 
 export function printMinified(query: DocumentNode): string {
-  return (
-    print(query)
-      // replace multi-spaces with single space
-      .replace(/\s{2,}/g, " ")
-      // remove spaces that are preceeded by braces
-      .replace(/(?<=[{}])\s+/g, "")
-      // remove spaces that are preceeding braces
-      .replace(/\s+(?=[{}])/g, "")
-      .trim()
-  );
+  return stripIgnoredCharacters(print(query));
 }


### PR DESCRIPTION
Right now, we transport the AST of a query over the network.

That's not optimal:

Normal Query:

```gql
  query dynamicProducts {
    products {
      id
      title
      foo {
        bar {
          baz {
            yoink
          }
        }
      }
    }
  }
```

is instead transported as
```json
{
  "kind": "Document",
  "definitions": [
    {
      "kind": "OperationDefinition",
      "operation": "query",
      "name": {
        "kind": "Name",
        "value": "dynamicProducts"
      },
      "variableDefinitions": [],
      "directives": [],
      "selectionSet": {
        "kind": "SelectionSet",
        "selections": [
          {
            "kind": "Field",
            "name": {
              "kind": "Name",
              "value": "products"
            },
            "arguments": [],
            "directives": [],
            "selectionSet": {
              "kind": "SelectionSet",
              "selections": [
                {
                  "kind": "Field",
                  "name": {
                    "kind": "Name",
                    "value": "id"
                  },
                  "arguments": [],
                  "directives": []
                },
                {
                  "kind": "Field",
                  "name": {
                    "kind": "Name",
                    "value": "title"
                  },
                  "arguments": [],
                  "directives": []
                },
                {
                  "kind": "Field",
                  "name": {
                    "kind": "Name",
                    "value": "foo"
                  },
                  "arguments": [],
                  "directives": [],
                  "selectionSet": {
                    "kind": "SelectionSet",
                    "selections": [
                      {
                        "kind": "Field",
                        "name": {
                          "kind": "Name",
                          "value": "bar"
                        },
                        "arguments": [],
                        "directives": [],
                        "selectionSet": {
                          "kind": "SelectionSet",
                          "selections": [
                            {
                              "kind": "Field",
                              "name": {
                                "kind": "Name",
                                "value": "baz"
                              },
                              "arguments": [],
                              "directives": [],
                              "selectionSet": {
                                "kind": "SelectionSet",
                                "selections": [
                                  {
                                    "kind": "Field",
                                    "name": {
                                      "kind": "Name",
                                      "value": "yoink"
                                    },
                                    "arguments": [],
                                    "directives": []
                                  }
                                ]
                              }
                            }
                          ]
                        }
                      }
                    ]
                  }
                }
              ]
            }
          }
        ]
      }
    }
  ],
  "loc": {
    "start": 0,
    "end": 163
  }
}
```
and instead we could go smaller and transport
```gql
query dynamicProducts{products{id title foo{bar{baz{yoink}}}}}
```