### PR TITLE
Allow using the browser build of `ApolloNextAppProvider` outside of Next.js, e.g. for tests.

### DIFF
--- a/integration-test/yarn.lock
+++ b/integration-test/yarn.lock
@@ -32,13 +32,12 @@ __metadata:
   linkType: hard
 
 "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs::locator=%40integration-test%2Froot%40workspace%3A.":
-  version: 0.8.0
+  version: 0.10.0
   resolution: "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs#./shared/build-client-react-streaming.cjs::hash=48b117&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
-    superjson: "npm:^1.12.2 || ^2.0.0"
     ts-invariant: "npm:^0.10.3"
   peerDependencies:
-    "@apollo/client": ^3.9.0
+    "@apollo/client": ^3.9.6
     react: ^18
   checksum: 10/8e12155ebcb9672f5b645c364d356018014df750412c61613341121ebb4d4eabb5f42cd9018cc3a81ad988f1b425548d68254ca49ede19c31d0d9e5a9a4f240a
   languageName: node
@@ -82,12 +81,12 @@ __metadata:
   linkType: hard
 
 "@apollo/experimental-nextjs-app-support@exec:./shared/build-experimental-nextjs-app-support.cjs::locator=%40integration-test%2Froot%40workspace%3A.":
-  version: 0.8.0
+  version: 0.10.0
   resolution: "@apollo/experimental-nextjs-app-support@exec:./shared/build-experimental-nextjs-app-support.cjs#./shared/build-experimental-nextjs-app-support.cjs::hash=fd83cc&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
-    "@apollo/client-react-streaming": "npm:^0.9.0"
+    "@apollo/client-react-streaming": "npm:0.10.0"
   peerDependencies:
-    "@apollo/client": ^3.9.0
+    "@apollo/client": ^3.9.6
     next: ^13.4.1 || ^14.0.0
     react: ^18
   checksum: 10/505b723bac0f3a7f15287ea32fab9f2e8c0cd567149abf11d750855f8a9bfc0aa26e44179ad10c32f7d162ad86318717032413ef8e1a25385185178e022588fa
@@ -3973,15 +3972,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-anything@npm:^3.0.2":
-  version: 3.0.5
-  resolution: "copy-anything@npm:3.0.5"
-  dependencies:
-    is-what: "npm:^4.1.8"
-  checksum: 10/4c41385a94a1cff6352a954f9b1c05b6bb1b70713a2d31f4c7b188ae7187ce00ddcc9c09bd58d24cd35b67fc6dd84df5954c0be86ea10700ff74e677db3cb09c
-  languageName: node
-  linkType: hard
-
 "core-js-compat@npm:^3.31.0, core-js-compat@npm:^3.34.0":
   version: 3.36.0
   resolution: "core-js-compat@npm:3.36.0"
@@ -5402,13 +5392,6 @@ __metadata:
     call-bind: "npm:^1.0.2"
     get-intrinsic: "npm:^1.1.1"
   checksum: 10/8f2ddb9639716fd7936784e175ea1183c5c4c05274c34f34f6a53175313cb1c9c35a8b795623306995e2f7cc8f25aa46302f15a2113e51c5052d447be427195c
-  languageName: node
-  linkType: hard
-
-"is-what@npm:^4.1.8":
-  version: 4.1.16
-  resolution: "is-what@npm:4.1.16"
-  checksum: 10/f6400634bae77be6903365dc53817292e1c4d8db1b467515d0c842505b8388ee8e558326d5e6952cb2a9d74116eca2af0c6adb8aa7e9d5c845a130ce9328bf13
   languageName: node
   linkType: hard
 
@@ -7956,15 +7939,6 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 10/4f6a5d0010770fdeea1183d919d528fd46c484e23c0535ef3e1dd49488116f639c594f3bd4440e3bc8a8686c9f8d53c5761599870ff039ede11a5c3bfe08a4be
-  languageName: node
-  linkType: hard
-
-"superjson@npm:^1.12.2 || ^2.0.0":
-  version: 2.2.1
-  resolution: "superjson@npm:2.2.1"
-  dependencies:
-    copy-anything: "npm:^3.0.2"
-  checksum: 10/bb8743a87c97f7845e0c27af1af0731d3185b32099ebce2aee0e67ac9a6ae9a7c4b9edfca7e1fe48693a78b56d5922d1cd13ef80c2fa12b788d3fc0ca25afe47
   languageName: node
   linkType: hard
 

--- a/integration-test/yarn.lock
+++ b/integration-test/yarn.lock
@@ -35,6 +35,7 @@ __metadata:
   version: 0.10.0
   resolution: "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs#./shared/build-client-react-streaming.cjs::hash=48b117&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
+    superjson: "npm:^1.12.2 || ^2.0.0"
     ts-invariant: "npm:^0.10.3"
   peerDependencies:
     "@apollo/client": ^3.9.6
@@ -3972,6 +3973,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"copy-anything@npm:^3.0.2":
+  version: 3.0.5
+  resolution: "copy-anything@npm:3.0.5"
+  dependencies:
+    is-what: "npm:^4.1.8"
+  checksum: 10/4c41385a94a1cff6352a954f9b1c05b6bb1b70713a2d31f4c7b188ae7187ce00ddcc9c09bd58d24cd35b67fc6dd84df5954c0be86ea10700ff74e677db3cb09c
+  languageName: node
+  linkType: hard
+
 "core-js-compat@npm:^3.31.0, core-js-compat@npm:^3.34.0":
   version: 3.36.0
   resolution: "core-js-compat@npm:3.36.0"
@@ -5392,6 +5402,13 @@ __metadata:
     call-bind: "npm:^1.0.2"
     get-intrinsic: "npm:^1.1.1"
   checksum: 10/8f2ddb9639716fd7936784e175ea1183c5c4c05274c34f34f6a53175313cb1c9c35a8b795623306995e2f7cc8f25aa46302f15a2113e51c5052d447be427195c
+  languageName: node
+  linkType: hard
+
+"is-what@npm:^4.1.8":
+  version: 4.1.16
+  resolution: "is-what@npm:4.1.16"
+  checksum: 10/f6400634bae77be6903365dc53817292e1c4d8db1b467515d0c842505b8388ee8e558326d5e6952cb2a9d74116eca2af0c6adb8aa7e9d5c845a130ce9328bf13
   languageName: node
   linkType: hard
 
@@ -7939,6 +7956,15 @@ __metadata:
     babel-plugin-macros:
       optional: true
   checksum: 10/4f6a5d0010770fdeea1183d919d528fd46c484e23c0535ef3e1dd49488116f639c594f3bd4440e3bc8a8686c9f8d53c5761599870ff039ede11a5c3bfe08a4be
+  languageName: node
+  linkType: hard
+
+"superjson@npm:^1.12.2 || ^2.0.0":
+  version: 2.2.1
+  resolution: "superjson@npm:2.2.1"
+  dependencies:
+    copy-anything: "npm:^3.0.2"
+  checksum: 10/bb8743a87c97f7845e0c27af1af0731d3185b32099ebce2aee0e67ac9a6ae9a7c4b9edfca7e1fe48693a78b56d5922d1cd13ef80c2fa12b788d3fc0ca25afe47
   languageName: node
   linkType: hard
 

--- a/packages/experimental-nextjs-app-support/src/ApolloNextAppProvider.ts
+++ b/packages/experimental-nextjs-app-support/src/ApolloNextAppProvider.ts
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { use } from "react";
 import { buildManualDataTransport } from "@apollo/client-react-streaming/manual-transport";
 import { WrapApolloProvider } from "@apollo/client-react-streaming";
 import { ServerInsertedHTMLContext } from "next/navigation.js";
@@ -44,10 +44,13 @@ import { bundle } from "./bundleInfo.js";
 export const ApolloNextAppProvider = /*#__PURE__*/ WrapApolloProvider(
   buildManualDataTransport({
     useInsertHtml() {
-      const insertHtml = useContext(ServerInsertedHTMLContext);
+      if (process.env.REACT_ENV === "browser") {
+        return () => {};
+      }
+      const insertHtml = use(ServerInsertedHTMLContext);
       if (!insertHtml) {
         throw new Error(
-          "ApolloNextAppProvider cannot be used outside of the Next App Router!"
+          "The SSR build of ApolloNextAppProvider cannot be used outside of the Next App Router!"
         );
       }
       return insertHtml;

--- a/packages/experimental-nextjs-app-support/src/ApolloNextAppProvider.ts
+++ b/packages/experimental-nextjs-app-support/src/ApolloNextAppProvider.ts
@@ -1,4 +1,4 @@
-import { use } from "react";
+import { useContext } from "react";
 import { buildManualDataTransport } from "@apollo/client-react-streaming/manual-transport";
 import { WrapApolloProvider } from "@apollo/client-react-streaming";
 import { ServerInsertedHTMLContext } from "next/navigation.js";
@@ -44,11 +44,12 @@ import { bundle } from "./bundleInfo.js";
 export const ApolloNextAppProvider = /*#__PURE__*/ WrapApolloProvider(
   buildManualDataTransport({
     useInsertHtml() {
-      if (process.env.REACT_ENV === "browser") {
-        return () => {};
-      }
-      const insertHtml = use(ServerInsertedHTMLContext);
+      const insertHtml = useContext(ServerInsertedHTMLContext);
       if (!insertHtml) {
+        if (process.env.REACT_ENV === "browser") {
+          //Allow using the browser build of ApolloNextAppProvider outside of Next.js, e.g. for tests.
+          return () => {};
+        }
         throw new Error(
           "The SSR build of ApolloNextAppProvider cannot be used outside of the Next App Router!"
         );

--- a/packages/experimental-nextjs-app-support/src/ApolloNextAppProvider.ts
+++ b/packages/experimental-nextjs-app-support/src/ApolloNextAppProvider.ts
@@ -51,7 +51,8 @@ export const ApolloNextAppProvider = /*#__PURE__*/ WrapApolloProvider(
           return () => {};
         }
         throw new Error(
-          "The SSR build of ApolloNextAppProvider cannot be used outside of the Next App Router!"
+          "The SSR build of ApolloNextAppProvider cannot be used outside of the Next App Router!\n" +
+            'If you encounter this in a test, make sure that your tests are using the browser build by adding the "browser" import condition to your test setup.'
         );
       }
       return insertHtml;


### PR DESCRIPTION
Closes #283