### PR TITLE
Update snapshot-release.yml

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -29,7 +29,7 @@ jobs:
         )
       )
     steps:
-      - uses: alessbell/pull-request-comment-branch@v1.1
+      - uses: alessbell/pull-request-comment-branch@v2.1.0
         if: github.event_name == 'issue_comment'
         id: comment-branch
 


### PR DESCRIPTION
Released a new version that uses Node 20, eliminates GHA warning about deprecated use of Node 16.