### PR TITLE
[⚠️ wip]  Experimental Transport of Async Iterables

### DIFF
--- a/examples/hack-the-supergraph-ssr/app/layout.tsx
+++ b/examples/hack-the-supergraph-ssr/app/layout.tsx
@@ -1,7 +1,71 @@
 import { cookies } from "next/headers";
-import { ClientLayout } from "./ClientLayout";
+import { registerApolloClient } from "@apollo/client-react-streaming";
+import {
+  gql,
+  ApolloClient,
+  InMemoryCache,
+  HttpLink,
+  TypedDocumentNode,
+} from "@apollo/client";
 
+import { ClientLayout } from "./ClientLayout";
 import { ApolloWrapper } from "./ApolloWrapper";
+
+const { PreloadQuery } = registerApolloClient(() => {
+  return new ApolloClient({
+    cache: new InMemoryCache(),
+    link: new HttpLink({
+      // this needs to be an absolute url, as relative urls cannot be used in SSR
+      uri: "https://main--hack-the-e-commerce.apollographos.net/graphql",
+      // you can disable result caching here if you want to
+      // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
+      fetchOptions: { cache: "no-store" },
+      // fetchOptions: { headers: { "x-custom-delay": "5000" } },
+    }),
+  });
+});
+
+const ProductCardProductFragment: TypedDocumentNode<{
+  id: string;
+  title: string;
+  description: string;
+  mediaUrl: string;
+}> = gql`
+  fragment ProductCardProductFragment on Product {
+    id
+    title
+    description
+    mediaUrl
+  }
+`;
+
+const ReviewsFragment: TypedDocumentNode<{
+  id: string;
+  reviews: {
+    rating: number;
+  };
+}> = gql`
+  fragment ReviewsFragment on Product {
+    description
+    reviews {
+      rating
+    }
+  }
+`;
+
+const GET_LATEST_PRODUCTS: TypedDocumentNode<{
+  products: { id: string }[];
+}> = gql`
+  query HomepageProducts {
+    products {
+      id
+      ...ProductCardProductFragment
+      ...ReviewsFragment @defer
+    }
+  }
+  ${ProductCardProductFragment}
+  ${ReviewsFragment}
+`;
 
 export default async function RootLayout({
   children,
@@ -9,13 +73,15 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const cookieStore = cookies();
-  const delay = Number(cookieStore.get("apollo-x-custom-delay")?.value ?? 1000);
+  const delay = Number(cookieStore.get("apollo-x-custom-delay")?.value ?? 5000);
 
   return (
     <html lang="en">
       <body>
         <ApolloWrapper delay={delay}>
-          <ClientLayout>{children}</ClientLayout>
+          <PreloadQuery query={GET_LATEST_PRODUCTS}>
+            <ClientLayout>{children}</ClientLayout>
+          </PreloadQuery>
         </ApolloWrapper>
       </body>
     </html>

--- a/examples/hack-the-supergraph-ssr/app/not-found.tsx
+++ b/examples/hack-the-supergraph-ssr/app/not-found.tsx
@@ -6,11 +6,8 @@ import Error from "./error";
 import Link from "next/link";
 
 export const Fallback = () => (
-  <Error code="404" error="This page could not be found">
-    <Button as={Link} href="/">
-      Home
-    </Button>
-  </Error>
+  <div>hi</div>
+  // <Error error={new Error("This page could not be found")} />
 );
 
 export default Fallback;

--- a/examples/hack-the-supergraph-ssr/app/page.tsx
+++ b/examples/hack-the-supergraph-ssr/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import ProductCard from "../components/ProductCard";
+import ProductCard, { Reviews } from "../components/ProductCard";
 import { Heading, SimpleGrid, Stack, Text, VStack } from "@chakra-ui/react";
 import { useSuspenseQuery, gql, TypedDocumentNode } from "@apollo/client";
 
@@ -11,14 +11,15 @@ const GET_LATEST_PRODUCTS: TypedDocumentNode<{
     products {
       id
       ...ProductCardProductFragment
+      ...ReviewsFragment @defer
     }
   }
   ${ProductCard.fragments.ProductCardProductFragment}
+  ${Reviews.fragments.ReviewsFragment}
 `;
 export default function HomePage() {
-  const { data } = useSuspenseQuery(GET_LATEST_PRODUCTS, {
-    fetchPolicy: "cache-first",
-  });
+  const { data } = useSuspenseQuery(GET_LATEST_PRODUCTS);
+
   return (
     <Stack direction="column" spacing="12">
       <VStack direction="column" spacing="2" py="10">

--- a/examples/hack-the-supergraph-ssr/app/product/[id]/page.tsx
+++ b/examples/hack-the-supergraph-ssr/app/product/[id]/page.tsx
@@ -31,7 +31,6 @@ const GET_PRODUCT_DETAILS: TypedDocumentNode<{
   };
 }> = gql`
   fragment ProductFragment on Product {
-    averageRating
     reviews {
       content
       rating

--- a/examples/hack-the-supergraph-ssr/components/DelaySlider.tsx
+++ b/examples/hack-the-supergraph-ssr/components/DelaySlider.tsx
@@ -25,7 +25,7 @@ export default function DelaySlider() {
       <Heading fontSize="md">
         Custom <code>@defer</code> Delay: {delay}ms
       </Heading>
-      <Slider min={0} max={500} value={delay} onChange={setDelay}>
+      <Slider min={0} max={5000} value={delay} onChange={setDelay}>
         <SliderTrack>
           <SliderFilledTrack />
         </SliderTrack>

--- a/examples/hack-the-supergraph-ssr/components/SettingsModal.tsx
+++ b/examples/hack-the-supergraph-ssr/components/SettingsModal.tsx
@@ -1,3 +1,4 @@
+"use client";
 import DelaySlider from "./DelaySlider";
 import {
   Button,

--- a/examples/hack-the-supergraph-ssr/package.json
+++ b/examples/hack-the-supergraph-ssr/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "yarn workspace @apollo/experimental-nextjs-app-support run build",
+    "prebuild": "yarn workspace @apollo/experimental-nextjs-app-support run build && yarn workspace @apollo/client-react-streaming run build",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {
-    "@apollo/client": "3.10.4",
+    "@apollo/client": "https://pkg.pr.new/@apollo/client@12066",
+    "@apollo/client-react-streaming": "workspace:^",
     "@apollo/experimental-nextjs-app-support": "workspace:^",
     "@apollo/space-kit": "^9.11.0",
     "@chakra-ui/next-js": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build:docmodel": "yarn workspaces foreach --all --include \"@apollo/*\" exec api-extractor run"
   },
   "resolutions": {
+    "@apollo/client": "https://pkg.pr.new/@apollo/client@12066",
     "react": "19.0.0-rc-935180c7e0-20240524",
     "react-dom": "19.0.0-rc-935180c7e0-20240524",
     "react-server-dom-webpack": "19.0.0-beta-94eed63c49-20240425",

--- a/packages/client-react-streaming/src/transportedQueryRef.ts
+++ b/packages/client-react-streaming/src/transportedQueryRef.ts
@@ -50,8 +50,8 @@ export interface InternalTransportedQueryRef<
 
 export function createTransportedQueryRef<TData, TVariables>(
   options: TransportedQueryRefOptions,
-  queryKey: string,
-  _promise: Promise<any>
+  queryKey: string
+  // _promise: Promise<any>
 ): InternalTransportedQueryRef<TData, TVariables> {
   const ref: InternalTransportedQueryRef<TData, TVariables> = {
     __transportedQueryRef: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client-react-streaming@workspace:*, @apollo/client-react-streaming@workspace:packages/client-react-streaming":
+"@apollo/client-react-streaming@workspace:*, @apollo/client-react-streaming@workspace:^, @apollo/client-react-streaming@workspace:packages/client-react-streaming":
   version: 0.0.0-use.local
   resolution: "@apollo/client-react-streaming@workspace:packages/client-react-streaming"
   dependencies:
@@ -86,9 +86,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@apollo/client@npm:3.10.4, @apollo/client@npm:^3.10.4":
-  version: 3.10.4
-  resolution: "@apollo/client@npm:3.10.4"
+"@apollo/client@https://pkg.pr.new/@apollo/client@12066":
+  version: 3.11.8
+  resolution: "@apollo/client@https://pkg.pr.new/@apollo/client@12066"
   dependencies:
     "@graphql-typed-document-node/core": "npm:^3.1.1"
     "@wry/caches": "npm:^1.0.0"
@@ -107,8 +107,8 @@ __metadata:
   peerDependencies:
     graphql: ^15.0.0 || ^16.0.0
     graphql-ws: ^5.5.5
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0
     subscriptions-transport-ws: ^0.9.0 || ^0.11.0
   peerDependenciesMeta:
     graphql-ws:
@@ -119,7 +119,7 @@ __metadata:
       optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: 10/8db77625bb96f3330187a6b45c9792edf338c42d4e48ed66f6b0ce38c7cea503db9a5de27f9987b7d83306201a57f90e8ef7ebc06c8a6899aaadb8a090b175cb
+  checksum: 10/07390b7bb044f64f5228844a8e5cfa1aa9c13c419afc7d0f32b4d20831a995c0d0c2a044e59211923a33f6407e8131a811587a18fb4adb20137cd134b8e8789e
   languageName: node
   linkType: hard
 
@@ -10093,7 +10093,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "hack-the-supergraph-ssr@workspace:examples/hack-the-supergraph-ssr"
   dependencies:
-    "@apollo/client": "npm:3.10.4"
+    "@apollo/client": "https://pkg.pr.new/@apollo/client@12066"
+    "@apollo/client-react-streaming": "workspace:^"
     "@apollo/experimental-nextjs-app-support": "workspace:^"
     "@apollo/space-kit": "npm:^9.11.0"
     "@chakra-ui/next-js": "npm:^2.1.2"


### PR DESCRIPTION
Experimenting with a multipart response in a server query containing `@defer` via `PreloadQuery` that can be consumed in a client component, triggering multiple re-renders as the chunks are transported over the server <> client boundary.