### PR TITLE
make the hook hydration cache resilient against unmounted recreation of `ManualDataTransport`

### DIFF
--- a/packages/client-react-streaming/src/ManualDataTransport/ApolloRehydrateSymbols.tsx
+++ b/packages/client-react-streaming/src/ManualDataTransport/ApolloRehydrateSymbols.tsx
@@ -1,10 +1,16 @@
 import type { DataTransport } from "./dataTransport.js";
+import type { RehydrationCache } from "./types.js";
 
 declare global {
   interface Window {
     [ApolloSSRDataTransport]?: DataTransport<unknown>;
+    [ApolloHookRehydrationCache]?: RehydrationCache;
   }
 }
 export const ApolloSSRDataTransport = /*#__PURE__*/ Symbol.for(
   "ApolloSSRDataTransport"
+);
+
+export const ApolloHookRehydrationCache = /*#__PURE__*/ Symbol.for(
+  "apollo.hookRehydrationCache"
 );

--- a/packages/client-react-streaming/src/ManualDataTransport/ManualDataTransport.tsx
+++ b/packages/client-react-streaming/src/ManualDataTransport/ManualDataTransport.tsx
@@ -6,6 +6,7 @@ import type { HydrationContextOptions } from "./RehydrationContext.js";
 import { buildApolloRehydrationContext } from "./RehydrationContext.js";
 import { registerDataTransport } from "./dataTransport.js";
 import { revive, stringify } from "./serialization.js";
+import { ApolloHookRehydrationCache } from "./ApolloRehydrateSymbols.js";
 
 export interface ManualDataTransportOptions {
   /**
@@ -81,7 +82,9 @@ const buildManualDataTransportBrowserImpl = ({
     onQueryEvent,
     rerunSimulatedQueries,
   }) {
-    const hookRehydrationCache = useRef<RehydrationCache>({});
+    const hookRehydrationCache = useRef<RehydrationCache>(
+      (window[ApolloHookRehydrationCache] ??= {})
+    );
     registerDataTransport({
       onQueryEvent: onQueryEvent!,
       onRehydrate(rehydrate) {

--- a/packages/client-react-streaming/src/ManualDataTransport/index.ts
+++ b/packages/client-react-streaming/src/ManualDataTransport/index.ts
@@ -2,7 +2,10 @@ export { buildManualDataTransport } from "./ManualDataTransport.js";
 
 export type { HydrationContextOptions } from "./RehydrationContext.js";
 
-import { ApolloSSRDataTransport } from "./ApolloRehydrateSymbols.js";
+import {
+  ApolloHookRehydrationCache,
+  ApolloSSRDataTransport,
+} from "./ApolloRehydrateSymbols.js";
 import { resetApolloSingletons } from "@apollo/client-react-streaming";
 
 /**
@@ -19,5 +22,6 @@ import { resetApolloSingletons } from "@apollo/client-react-streaming";
  */
 export function resetManualSSRApolloSingletons() {
   resetApolloSingletons();
+  delete window[ApolloHookRehydrationCache];
   delete window[ApolloSSRDataTransport];
 }


### PR DESCRIPTION
This should fix the issue with an hydration error of `useQuery` that came up in #368, where no suspense boundary existed and as a result, the `useRef` of `ManualDataTransport` became re-initialized.