### PR TITLE
do not bundle parts of the `graphql` package

### DIFF
--- a/integration-test/yarn.lock
+++ b/integration-test/yarn.lock
@@ -32,7 +32,7 @@ __metadata:
   linkType: hard
 
 "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs::locator=%40integration-test%2Froot%40workspace%3A.":
-  version: 0.11.4
+  version: 0.11.5
   resolution: "@apollo/client-react-streaming@exec:./shared/build-client-react-streaming.cjs#./shared/build-client-react-streaming.cjs::hash=48b117&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
     ts-invariant: "npm:^0.10.3"
@@ -81,10 +81,10 @@ __metadata:
   linkType: hard
 
 "@apollo/experimental-nextjs-app-support@exec:./shared/build-experimental-nextjs-app-support.cjs::locator=%40integration-test%2Froot%40workspace%3A.":
-  version: 0.11.4
+  version: 0.11.5
   resolution: "@apollo/experimental-nextjs-app-support@exec:./shared/build-experimental-nextjs-app-support.cjs#./shared/build-experimental-nextjs-app-support.cjs::hash=fd83cc&locator=%40integration-test%2Froot%40workspace%3A."
   dependencies:
-    "@apollo/client-react-streaming": "npm:0.11.4"
+    "@apollo/client-react-streaming": "npm:0.11.5"
   peerDependencies:
     "@apollo/client": ^3.10.4
     next: ^13.4.1 || ^14.0.0 || ^15.0.0-rc.0

--- a/packages/client-react-streaming/tsup.config.ts
+++ b/packages/client-react-streaming/tsup.config.ts
@@ -18,6 +18,7 @@ export default defineConfig((options) => {
     outDir: "dist/",
     external: [
       "@apollo/client-react-streaming",
+      "graphql",
       "react",
       "rehackt",
       "react-dom",


### PR DESCRIPTION
I'm not sure when and why that happened, but it seems like we've been bundling parts of the `graphql` package in recent releases.

This fixes that.