### PR TITLE
run playwright tests only against next.js deployment

### DIFF
--- a/.github/workflows/vercel-integration.yml
+++ b/.github/workflows/vercel-integration.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log the deployment status
-        run: echo "Deployment status is ${{ toJSON(toJSON(github.event.deployment_status)) }}"
+        run: echo 'Deployment status is ${{ toJSON(github.event.deployment_status) }}'
 
   run-next-e2e:
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – apollo__experimental-nextjs-app-support'

--- a/.github/workflows/vercel-integration.yml
+++ b/.github/workflows/vercel-integration.yml
@@ -4,7 +4,7 @@ on:
   deployment_status:
 jobs:
   log:
-    runs-on: ubuntu-latest`
+    runs-on: ubuntu-latest
     steps:
       - name: Log the deployment status
         run: echo "Deployment status is ${{ toJSON(github.event.deployment_status) }}"

--- a/.github/workflows/vercel-integration.yml
+++ b/.github/workflows/vercel-integration.yml
@@ -4,7 +4,7 @@ on:
   deployment_status:
 jobs:
   run-e2es:
-    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – apollo__client-integration-tanstack-start'
     runs-on: ubuntu-latest
     name: Run Playwright tests against Vercel deployment
     defaults:

--- a/.github/workflows/vercel-integration.yml
+++ b/.github/workflows/vercel-integration.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Vercel Integration Tests
 
 on:
   deployment_status:
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log the deployment status
-        run: echo "Deployment status is ${{ toJSON(github.event.deployment_status) }}"
+        run: echo "Deployment status is ${{ toJSON(toJSON(github.event.deployment_status)) }}"
 
-  run-e2es:
-    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – apollo__client-integration-tanstack-start'
+  run-next-e2e:
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – apollo__experimental-nextjs-app-support'
     runs-on: ubuntu-latest
     name: Run Playwright tests against Vercel deployment
     defaults:

--- a/.github/workflows/vercel-integration.yml
+++ b/.github/workflows/vercel-integration.yml
@@ -3,6 +3,12 @@ name: Playwright Tests
 on:
   deployment_status:
 jobs:
+  log:
+    runs-on: ubuntu-latest`
+    steps:
+      - name: Log the deployment status
+        run: echo "Deployment status is ${{ toJSON(github.event.deployment_status) }}"
+
   run-e2es:
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – apollo__client-integration-tanstack-start'
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have two deployments now and I also renamed it - so this ensures that the e2e tests for Next.js only run for Next.js deployments