### PR TITLE
Handle closing head tag split across chunks

### DIFF
--- a/.changeset/strange-boats-type.md
+++ b/.changeset/strange-boats-type.md
@@ -1,0 +1,5 @@
+---
+"@apollo/client-react-streaming": patch
+---
+
+`createInjectionTransformStream`: fix handling if `</head>` is chopped up into multiple chunks

--- a/packages/client-react-streaming/src/stream-utils/createInjectionTransformStream.test.tsx
+++ b/packages/client-react-streaming/src/stream-utils/createInjectionTransformStream.test.tsx
@@ -1,5 +1,4 @@
 import { test } from "node:test";
-import { createInjectionTransformStream } from "./createInjectionTransformStream.js";
 import {
   ReadableStream,
   type TransformStream,
@@ -9,6 +8,13 @@ import * as assert from "node:assert";
 import { text } from "node:stream/consumers";
 import React from "react";
 import { scheduler } from "node:timers/promises";
+import { runInConditions } from "@internal/test-utils/runInConditions.js";
+
+runInConditions("node");
+
+const { createInjectionTransformStream } = await import(
+  "./createInjectionTransformStream.js"
+);
 
 function html(strings: TemplateStringsArray) {
   return strings[0]

--- a/packages/client-react-streaming/src/stream-utils/createInjectionTransformStream.test.tsx
+++ b/packages/client-react-streaming/src/stream-utils/createInjectionTransformStream.test.tsx
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import { createInjectionTransformStream } from "./createInjectionTransformStream.js";
+import {
+  ReadableStream,
+  type TransformStream,
+  TextEncoderStream,
+} from "node:stream/web";
+import * as assert from "node:assert";
+import { text } from "node:stream/consumers";
+import React from "react";
+import { scheduler } from "node:timers/promises";
+
+function html(strings: TemplateStringsArray) {
+  return strings[0]
+    .split("\n")
+    .map((line) => line.trim())
+    .join("");
+}
+
+const emptyHtml = html`<html>
+  <head>
+    <title>Test</title>
+  </head>
+  <body></body>
+</html>`;
+function TestComponent() {
+  return (
+    <script dangerouslySetInnerHTML={{ __html: `console.log("test");` }} />
+  );
+}
+
+function setupStream(transform: globalThis.TransformStream<any, any>) {
+  let controller: ReadableStreamDefaultController<string>;
+  const stream = new ReadableStream<string>({
+    start(c) {
+      controller = c;
+    },
+  })
+    .pipeThrough(new TextEncoderStream())
+    .pipeThrough(transform as TransformStream);
+  const resultPromise = text(stream);
+  return { resultPromise, controller: controller! };
+}
+
+test("equality transformation", async () => {
+  const { transformStream } = createInjectionTransformStream();
+  const { resultPromise, controller } = setupStream(transformStream);
+
+  controller.enqueue(emptyHtml);
+  controller.close();
+
+  assert.equal(await resultPromise, emptyHtml);
+});
+
+test("if the head has not been flushed yet, inject before the end of head", async () => {
+  const { transformStream, injectIntoStream } =
+    createInjectionTransformStream();
+  const { resultPromise, controller } = setupStream(transformStream);
+
+  controller.enqueue(emptyHtml);
+  injectIntoStream(() => <TestComponent />);
+  controller.close();
+
+  assert.equal(
+    await resultPromise,
+    html`<html>
+      <head>
+        <title>Test</title>
+        <script>
+          console.log("test");
+        </script>
+      </head>
+      <body></body>
+    </html>`
+  );
+});
+
+test("if the head has been flushed, just insert wherever", async () => {
+  const { transformStream, injectIntoStream } =
+    createInjectionTransformStream();
+  const { resultPromise, controller } = setupStream(transformStream);
+
+  controller.enqueue("<html><head><title>Test</title></head><body>");
+  await scheduler.wait(1);
+  injectIntoStream(() => <TestComponent />);
+  controller.enqueue("</body></html>");
+  controller.close();
+
+  assert.equal(
+    await resultPromise,
+    html`<html>
+      <head>
+        <title>Test</title>
+      </head>
+      <body>
+        <script>
+          console.log("test");
+        </script>
+      </body>
+    </html>`
+  );
+});
+
+test("if the head is chopped into pieces, take the last chunk into account when looking for the end of the head", async () => {
+  const { transformStream, injectIntoStream } =
+    createInjectionTransformStream();
+  const { resultPromise, controller } = setupStream(transformStream);
+
+  controller.enqueue(`<html><he`);
+  injectIntoStream(() => <TestComponent />);
+  await scheduler.wait(1);
+  controller.enqueue(`ad><title>Test</title></hea`);
+  await scheduler.wait(1);
+  controller.enqueue(`d><body></body></html>`);
+  await scheduler.wait(1);
+  controller.close();
+
+  assert.equal(
+    await resultPromise,
+    html`<html>
+      <head>
+        <title>Test</title>
+        <script>
+          console.log("test");
+        </script>
+      </head>
+      <body></body>
+    </html>`
+  );
+});


### PR DESCRIPTION
Fixes an issue where `createInjectionTransformStream` fails to inject any cache data into SSR output when the closing `</head>` happened to fall across the boundary between 2 chunks.

Fixes #431 
