### PR TITLE
Fix peer deps for tanstack lib

### DIFF
--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -93,7 +93,9 @@
     "@apollo/client": ">=3.13.0-rc.0",
     "@tanstack/react-router": "^1.99.6",
     "@tanstack/start": "^1.99.4",
-    "react": "^19"
+    "graphql": "^16 || >=17.0.0-alpha.2",
+    "react": "^19",
+    "react-dom": "^19"
   },
   "dependencies": {
     "@apollo/client-react-streaming": "0.12.0-alpha.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,7 +268,9 @@ __metadata:
     "@apollo/client": ">=3.13.0-rc.0"
     "@tanstack/react-router": ^1.99.6
     "@tanstack/start": ^1.99.4
+    graphql: ^16 || >=17.0.0-alpha.2
     react: ^19
+    react-dom: ^19
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
```
p41e2b → ✘ @apollo/client-integration-tanstack-start@npm:0.12.0-alpha.0 [400a2] doesn't provide graphql to @apollo/client-react-streaming@npm:0.12.0-alpha.0 [98aaf]
pcc06b → ✘ @apollo/client-integration-tanstack-start@npm:0.12.0-alpha.0 [400a2] doesn't provide react-dom to @apollo/client-react-streaming@npm:0.12.0-alpha.0 [98aaf]
