### PR TITLE
Export PreloadQueryRef

### DIFF
--- a/.changeset/tidy-taxis-jam.md
+++ b/.changeset/tidy-taxis-jam.md
@@ -1,0 +1,6 @@
+---
+"@apollo/client-react-streaming": minor
+"@apollo/client-integration-nextjs": minor
+---
+
+Export `PreloadQueryRef`, and add `PreloadQueryRef` to the object returned by `registerApolloClient` for query-ref-first preloading flows.

--- a/integration-test/nextjs/package.json
+++ b/integration-test/nextjs/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@apollo/client": "^4.0.0",
     "@apollo/client-integration-nextjs": "workspace:^",
+    "@apollo/client-react-streaming": "workspace:^",
     "@apollo/server": "^4.11.2",
     "@as-integrations/next": "^3.2.0",
     "@graphql-tools/schema": "^10.0.0",

--- a/integration-test/nextjs/src/app/rsc/client.ts
+++ b/integration-test/nextjs/src/app/rsc/client.ts
@@ -17,12 +17,13 @@ setLogVerbosity("debug");
 loadDevMessages();
 loadErrorMessages();
 
-export const { getClient, PreloadQuery, query } = registerApolloClient(() => {
-  return new ApolloClient({
-    cache: new InMemoryCache(),
-    link: delayLink.concat(
-      errorLink.concat(new IncrementalSchemaLink({ schema }))
-    ),
-    incrementalHandler: new Defer20220824Handler(),
+export const { getClient, PreloadQuery, PreloadQueryRef, query } =
+  registerApolloClient(() => {
+    return new ApolloClient({
+      cache: new InMemoryCache(),
+      link: delayLink.concat(
+        errorLink.concat(new IncrementalSchemaLink({ schema }))
+      ),
+      incrementalHandler: new Defer20220824Handler(),
+    });
   });
-});

--- a/integration-test/nextjs/src/app/rsc/dynamic/PreloadQueryRef/queryRef-useReadQuery/page.tsx
+++ b/integration-test/nextjs/src/app/rsc/dynamic/PreloadQueryRef/queryRef-useReadQuery/page.tsx
@@ -1,0 +1,30 @@
+import { ApolloWrapper } from "@/app/cc/ApolloWrapper";
+import { ClientChild } from "../../PreloadQuery/queryRef-useReadQuery/ClientChild";
+import { QUERY } from "@integration-test/shared/queries";
+import { createTransportedQueryPreloader } from "@apollo/client-react-streaming";
+import { Suspense } from "react";
+import { getClient, PreloadQueryRef } from "../../../client";
+
+export const dynamic = "force-dynamic";
+
+export default async function Page({ searchParams }: { searchParams?: any }) {
+  const preloader = createTransportedQueryPreloader(await getClient(), {
+    notTransportedOptionOverrides: { fetchPolicy: "no-cache" },
+  });
+  const queryRef = preloader(QUERY, {
+    context: {
+      delay: 1000,
+      error: (await searchParams)?.errorIn || undefined,
+    },
+  });
+
+  return (
+    <ApolloWrapper>
+      <PreloadQueryRef queryRef={queryRef}>
+        <Suspense fallback={<>loading</>}>
+          <ClientChild queryRef={queryRef} />
+        </Suspense>
+      </PreloadQueryRef>
+    </ApolloWrapper>
+  );
+}

--- a/integration-test/playwright/src/preloadQuery.test.ts
+++ b/integration-test/playwright/src/preloadQuery.test.ts
@@ -7,6 +7,7 @@ const reactErr419 = /(Minified React error #419|Switched to client rendering)/;
 const base = matchesTag("@nextjs")
   ? "/rsc/dynamic/PreloadQuery"
   : "/preloadQuery";
+const preloadQueryRefBase = "/rsc/dynamic/PreloadQueryRef";
 
 const originatesIn = matchesTag("@nextjs") ? "RSC" : "SSR";
 const otherEnvs = matchesTag("@nextjs") ? "ssr,browser" : "browser";
@@ -160,6 +161,52 @@ test.describe("PreloadQuery", () => {
     },
     async ({ page }) => {
       await page.goto(`${base}/queryRef-useReadQuery`, {
+        waitUntil: "commit",
+      });
+
+      await expect(page).toBeInitiallyLoading(true);
+      await expect(page.getByText("loading")).not.toBeVisible();
+      await expect(page.getByText("Soft Warm Apollo Beanie")).toBeVisible();
+      await expect(
+        page.getByText(`Queried in ${originatesIn} environment`)
+      ).toBeVisible();
+
+      await page.getByRole("button", { name: "refetch" }).click();
+      await expect(
+        page.getByText("Queried in Browser environment")
+      ).toBeVisible();
+    }
+  );
+
+  test(
+    "PreloadQueryRef resolves on the server",
+    {
+      tag: ["@nextjs"],
+    },
+    async ({ page }) => {
+      await page.goto(
+        `${preloadQueryRefBase}/queryRef-useReadQuery?errorIn=${otherEnvs}`,
+        {
+          waitUntil: "commit",
+        }
+      );
+
+      await expect(page).toBeInitiallyLoading(true);
+      await expect(page.getByText("loading")).not.toBeVisible();
+      await expect(page.getByText("Soft Warm Apollo Beanie")).toBeVisible();
+      await expect(
+        page.getByText(`Queried in ${originatesIn} environment`)
+      ).toBeVisible();
+    }
+  );
+
+  test(
+    "PreloadQueryRef works with useQueryRefHandlers",
+    {
+      tag: ["@nextjs"],
+    },
+    async ({ page }) => {
+      await page.goto(`${preloadQueryRefBase}/queryRef-useReadQuery`, {
         waitUntil: "commit",
       });
 

--- a/packages/client-react-streaming/package-shape.json
+++ b/packages/client-react-streaming/package-shape.json
@@ -14,6 +14,7 @@
       "createTransportedQueryPreloader",
       "isTransportedQueryRef",
       "reviveTransportedQueryRef",
+      "PreloadQueryRef",
       "built_for_rsc"
     ],
     "browser": [
@@ -34,6 +35,7 @@
       "isTransportedQueryRef",
       "reviveTransportedQueryRef",
       "useWrapTransportedQueryRef",
+      "PreloadQueryRef",
       "built_for_browser"
     ],
     "node": [
@@ -54,6 +56,7 @@
       "isTransportedQueryRef",
       "reviveTransportedQueryRef",
       "useWrapTransportedQueryRef",
+      "PreloadQueryRef",
       "built_for_ssr"
     ],
     "edge-light,worker,browser": [
@@ -74,6 +77,7 @@
       "isTransportedQueryRef",
       "reviveTransportedQueryRef",
       "useWrapTransportedQueryRef",
+      "PreloadQueryRef",
       "built_for_ssr"
     ],
     "workerd,worker,module,browser": [
@@ -94,6 +98,7 @@
       "isTransportedQueryRef",
       "reviveTransportedQueryRef",
       "useWrapTransportedQueryRef",
+      "PreloadQueryRef",
       "built_for_ssr"
     ]
   },

--- a/packages/client-react-streaming/src/PreloadQuery.tsx
+++ b/packages/client-react-streaming/src/PreloadQuery.tsx
@@ -1,4 +1,4 @@
-import { SimulatePreloadedQuery } from "./index.cc.js";
+import { PreloadQueryRef } from "./index.cc.js";
 import type {
   ApolloClient,
   DocumentNode,
@@ -58,8 +58,8 @@ export async function PreloadQuery<
   );
 
   return (
-    <SimulatePreloadedQuery<TData> queryRef={queryRef}>
+    <PreloadQueryRef<TData> queryRef={queryRef}>
       {typeof children === "function" ? children(queryRef) : children}
-    </SimulatePreloadedQuery>
+    </PreloadQueryRef>
   );
 }

--- a/packages/client-react-streaming/src/PreloadQueryRef.cc.ts
+++ b/packages/client-react-streaming/src/PreloadQueryRef.cc.ts
@@ -9,7 +9,8 @@ import {
 import { deserializeOptions } from "./DataTransportAbstraction/transportedOptions.js";
 import type { PreloadQueryOptions } from "./PreloadQuery.js";
 
-export default function SimulatePreloadedQuery<T>({
+/** @public */
+export default function PreloadQueryRef<T>({
   queryRef,
   children,
 }: {

--- a/packages/client-react-streaming/src/index.cc.tsx
+++ b/packages/client-react-streaming/src/index.cc.tsx
@@ -2,13 +2,21 @@
 
 import * as React from "react";
 
-let RealSimulatePreloadedQuery: typeof import("./SimulatePreloadedQuery.cc.js").default;
-export const SimulatePreloadedQuery: typeof import("./SimulatePreloadedQuery.cc.js").default =
+let RealPreloadQueryRef: typeof import("./PreloadQueryRef.cc.js").default;
+/**
+ * Hydrates a pre-created `TransportedQueryRef` into Apollo Client's suspense cache.
+ *
+ * This is the lower-level primitive used by `PreloadQuery`. Use it when you
+ * already created a `queryRef` with `createTransportedQueryPreloader`.
+ *
+ * @public
+ */
+export const PreloadQueryRef: typeof import("./PreloadQueryRef.cc.js").default =
   (props) => {
-    if (!RealSimulatePreloadedQuery) {
-      RealSimulatePreloadedQuery = React.lazy(
-        () => import("./SimulatePreloadedQuery.cc.js")
+    if (!RealPreloadQueryRef) {
+      RealPreloadQueryRef = React.lazy(
+        () => import("./PreloadQueryRef.cc.js")
       );
     }
-    return <RealSimulatePreloadedQuery {...props} />;
+    return <RealPreloadQueryRef {...props} />;
   };

--- a/packages/client-react-streaming/src/index.rsc.ts
+++ b/packages/client-react-streaming/src/index.rsc.ts
@@ -3,4 +3,5 @@ export type {
   PreloadQueryComponent,
   PreloadQueryProps,
 } from "./registerApolloClient.js";
+export { PreloadQueryRef } from "./index.cc.js";
 export * from "./index.shared.js";

--- a/packages/client-react-streaming/src/index.ts
+++ b/packages/client-react-streaming/src/index.ts
@@ -9,3 +9,4 @@ export {
   skipDataTransport,
 } from "./DataTransportAbstraction/index.js";
 export { useWrapTransportedQueryRef } from "./transportedQueryRef.js";
+export { PreloadQueryRef } from "./index.cc.js";

--- a/packages/client-react-streaming/src/registerApolloClient.tsx
+++ b/packages/client-react-streaming/src/registerApolloClient.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { cache } from "react";
 import type { PreloadQuery } from "./PreloadQuery.js";
 import { PreloadQuery as UnboundPreloadQuery } from "./PreloadQuery.js";
+import { PreloadQueryRef } from "./index.cc.js";
 
 const seenWrappers = WeakSet
   ? new WeakSet<{ client: ApolloClient | Promise<ApolloClient> }>()
@@ -22,7 +23,7 @@ const checkForStableCache = cache(() => ({}));
  *
  * @example
  * ```ts
- * export const { getClient, query, PreloadQuery } = registerApolloClient(() => {
+ * export const { getClient, query, PreloadQuery, PreloadQueryRef } = registerApolloClient(() => {
  *   return new ApolloClient({
  *     cache: new InMemoryCache(),
  *     link: new HttpLink({
@@ -76,8 +77,12 @@ export function registerApolloClient<
    *    </Suspense>
    *  </PreloadQuery>
    * ```
-   */
+  */
   PreloadQuery: PreloadQueryComponent;
+  /**
+   * Hydrates a `queryRef` created ahead of render for usage in Client Components.
+   */
+  PreloadQueryRef: typeof PreloadQueryRef;
 } {
   const getClient = makeGetClient(makeClient);
   /*
@@ -108,6 +113,7 @@ function and then call \`client.query\` multiple times instead.
       return (await getClient()).query(...args);
     },
     PreloadQuery,
+    PreloadQueryRef,
   };
 }
 

--- a/packages/client-react-streaming/tsup.config.ts
+++ b/packages/client-react-streaming/tsup.config.ts
@@ -87,8 +87,8 @@ export default defineConfig((options) => {
     {
       ...entry(
         "browser",
-        "src/SimulatePreloadedQuery.cc.ts",
-        "SimulatePreloadedQuery.cc"
+        "src/PreloadQueryRef.cc.ts",
+        "PreloadQueryRef.cc"
       ),
       treeshake: false, // would remove the "use client" directive
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6792,6 +6792,7 @@ __metadata:
   dependencies:
     "@apollo/client": "npm:^4.0.0"
     "@apollo/client-integration-nextjs": "workspace:^"
+    "@apollo/client-react-streaming": "workspace:^"
     "@apollo/server": "npm:^4.11.2"
     "@as-integrations/next": "npm:^3.2.0"
     "@graphql-tools/schema": "npm:^10.0.0"


### PR DESCRIPTION
This exports `PreloadQueryRef` as a public API and adds it to the object returned by `registerApolloClient`.

Until now, it only existed as an internal helper used by `PreloadQuery` under the name `SimulatePreloadedQuery`.

## Why

`PreloadQuery` starts the query from where it appears in the render tree, so the request does not begin until React gets there.

This makes it harder to parallelise GraphQL queries with other async work (REST calls, auth checks, etc.) at the top of a Server Component.

`PreloadQueryRef` makes that flow a bit more flexible. You can create the `queryRef` early with `createTransportedQueryPreloader`, start the query right away, and render `<PreloadQueryRef>` later to hydrate it into the client tree.

## Usage

```tsx
export default async function Page() {
  const preloader = createTransportedQueryPreloader(await getClient());

  const queryRef = preloader(MY_QUERY, {
    variables: { id: "1" },
  });

  const otherData = await fetchSomeRestEndpoint();

  return (
    <ApolloWrapper>
      <PreloadQueryRef queryRef={queryRef}>
        <Suspense fallback={<>loading...</>}>
          <ClientChild queryRef={queryRef} otherData={otherData} />
        </Suspense>
      </PreloadQueryRef>
    </ApolloWrapper>
  );
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exported `PreloadQueryRef` as a public API, now available through `registerApolloClient`, enabling query-ref-first preloading workflows for improved data fetching patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->