### PR TITLE
switch over to npm staged publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
-          node-version: "24.x"
+          node-version: ">=26.3.0"
           registry-url: "https://registry.npmjs.org"
           # deliberately not using a cache for action with elevated permissions, see https://tanstack.com/blog/npm-supply-chain-compromise-postmortem
           package-manager-cache: false
@@ -69,6 +69,9 @@ jobs:
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # shim around npm to convert `npm publish` to `npm stage publish` for staged publishing until changesets adds direct support for staged publishing.
+      - run: echo "${{ github.workspace }}/scripts/changesets-wrapper" >> "$GITHUB_PATH"
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/scripts/changesets-wrapper/npm
+++ b/scripts/changesets-wrapper/npm
@@ -5,14 +5,15 @@
 #
 set -euo pipefail
 
-# we assume that this binary was called because it's the first matching `npm` in PATH,
-# so we remove this directory from PATH and find the real npm binary that way
+# Find the real npm by temporarily excluding this directory from PATH,
+# but do NOT export the modified PATH — child processes (e.g. changeset publish)
+# must still see this wrapper so their own `npm publish` calls get rewritten too.
 SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-export PATH="${PATH//$SELF_DIR:/}"
+REAL_NPM="$(PATH="${PATH//$SELF_DIR:/}" command -v npm)"
 
 if [ "${1:-}" = "publish" ]; then
 	shift
-	exec npm stage publish "$@"
+	exec "$REAL_NPM" stage publish "$@"
 fi
 
-exec npm "$@"
+exec "$REAL_NPM" "$@"

--- a/scripts/changesets-wrapper/npm
+++ b/scripts/changesets-wrapper/npm
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Shim that rewrites `npm publish ...` to `npm stage publish ...`
+# (https://docs.npmjs.com/staged-publishing) and forwards every other
+# invocation to the real npm unchanged.
+#
+set -euo pipefail
+
+# we assume that this binary was called because it's the first matching `npm` in PATH,
+# so we remove this directory from PATH and find the real npm binary that way
+SELF_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+export PATH="${PATH//$SELF_DIR:/}"
+
+if [ "${1:-}" = "publish" ]; then
+	shift
+	exec npm stage publish "$@"
+fi
+
+exec npm "$@"


### PR DESCRIPTION
I've already changed the permissions on npm side:

```json
{
  "type": "github",
  "file": "publish.yml",
  "repository": "apollographql/apollo-client-integrations",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/client-integration-tanstack-start"
}
{
  "type": "github",
  "file": "publish.yml",
  "repository": "apollographql/apollo-client-integrations",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/client-integration-react-router"
}
{
  "type": "github",
  "file": "publish.yml",
  "repository": "apollographql/apollo-client-integrations",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/client-integration-nextjs"
}
{
  "type": "github",
  "file": "publish.yml",
  "repository": "apollographql/apollo-client-integrations",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/client-react-streaming"
}
{
  "type": "github",
  "file": "publish.yml",
  "repository": "apollographql/apollo-client-integrations",
  "permissions": [
    "createStagedPackage"
  ],
  "package": "@apollo/experimental-nextjs-app-support"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions Node.js setup to require version 26.3.0 or higher.
  * Added a publishing wrapper to translate `npm publish` into staged publishing, ensuring releases use the staged publish flow before proceeding with the existing release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->