### PR TITLE
fix(client-react-streaming): drop spurious refetch in SimulatePreloadedQuery

### DIFF
--- a/.changeset/tough-teachers-refetch.md
+++ b/.changeset/tough-teachers-refetch.md
@@ -1,0 +1,7 @@
+---
+"@apollo/client-react-streaming": patch
+---
+
+Fix `SimulatePreloadedQuery` firing a spurious network request that races the transported stream during hydration (#546).
+
+The extra `useBackgroundQuery` observable created next to the revived `queryRef` runs with the default `cache-first` policy. During hydration the transported result may not have reached the cache yet, so `cache-first` observes an empty cache and fires a duplicate network request for a query the server already executed. The revived `queryRef` already delivers the result via its stream-reading link chain (and falls back to the network on stream error), so the background query is skipped when the policy is `cache-first`. Callers that explicitly opt into `network-only` / `cache-and-network` are unaffected.

--- a/packages/client-react-streaming/src/SimulatePreloadedQuery.cc.ts
+++ b/packages/client-react-streaming/src/SimulatePreloadedQuery.cc.ts
@@ -1,6 +1,10 @@
 "use client";
 
-import { useApolloClient, useBackgroundQuery } from "@apollo/client/react";
+import {
+  skipToken,
+  useApolloClient,
+  useBackgroundQuery,
+} from "@apollo/client/react";
 import { useMemo, type ReactNode } from "react";
 import {
   reviveTransportedQueryRef,
@@ -29,7 +33,23 @@ export default function SimulatePreloadedQuery<T>({
     ] as const;
   }, [queryRef.$__apollo_queryRef]);
 
-  useBackgroundQuery(...bgQueryArgs);
+  // This background query is only here to keep the revived queryRef warm; the
+  // preloaded result itself is delivered through the queryRef's own
+  // stream-reading link chain (see reviveTransportedQueryRef /
+  // ReadFromReadableStreamLink), which falls back to the network if the stream
+  // errors. With the default `cache-first` policy, this extra observable races
+  // the transported-stream cache write during hydration: it can observe a
+  // still-empty cache and fire a duplicate network request for a query the
+  // server already executed (#546). Skip it in that case; callers that
+  // explicitly opted into a client-side refresh (`network-only` /
+  // `cache-and-network`) keep their fetch.
+  const bgOptions = bgQueryArgs[1];
+  const bgFetchPolicy =
+    (typeof bgOptions === "object" && bgOptions.fetchPolicy) || "cache-first";
+  useBackgroundQuery(
+    bgQueryArgs[0],
+    bgFetchPolicy === "cache-first" ? skipToken : bgOptions
+  );
 
   return children;
 }


### PR DESCRIPTION
## Summary

`SimulatePreloadedQuery` fires a duplicate, spurious network request for every `PreloadQuery`'d query right after hydration. This skips it.

Fixes #546.

## Bug

On a page that preloads data via `PreloadQuery`, the server runs the GraphQL query up front and streams the result to the browser along with the page — so the browser shouldn't need to ask for that data again.

But during hydration, `SimulatePreloadedQuery` calls `useBackgroundQuery` a *second* time as a redundant subscriber to the same query, alongside the revived `queryRef`. That hook defaults to `cache-first` ("use the cache if the data's there, otherwise fetch it"). Because of a **race**, the transported result often hasn't reached the cache yet at the moment the hook checks — so it sees an empty cache and fires a network request for data the server already delivered. (This is the race analyzed in #546.)

## Fix

The preloaded data doesn't actually arrive *through* that `useBackgroundQuery` call — it reaches components via the revived `queryRef`'s own stream-reading link chain (`reviveTransportedQueryRef` / `ReadFromReadableStreamLink`), which already falls back to the network if the stream errors. The background query is just a redundant duplicate reader. So when the policy is the default `cache-first`, we pass `skipToken` to make that call inert — and the duplicate request simply never happens.

Two behaviors are deliberately preserved:

- **Error recovery** — if the stream genuinely fails, the `queryRef`'s link chain still falls back to a real network fetch. We removed the *duplicate*, not the *recovery*.
- **Explicit fetch intent** — callers that opted into `network-only` / `cache-and-network` keep fetching, untouched. Only the passive default is skipped.

## Alternative considered

#546 suggests a deeper fix: reuse the `InternalQueryReference` already created by `reviveTransportedQueryRef` instead of creating a second observable — which would also address the secondary `queryKey`-mismatch vector the issue describes (a child `useSuspenseQuery` with no `queryKey` resolving to a different suspense-cache entry). This PR takes the smaller, targeted route to fix the observed duplicate request; happy to rework toward the `queryRef`-reuse approach if you'd prefer that shape.

## Testing

- `yarn test` for `@apollo/client-react-streaming` passes under all conditions (ssr / browser / rsc); `yarn build` and `yarn lint` are clean.
- The `integration-test/nextjs` Playwright suite passes, including the `PreloadQuery` cases — query resolves on the server, link-chain error restarts in the browser, graphqlError restarts, `queryRef` + `useReadQuery`, and `useQueryRefHandlers`.
- Verified in a production Next.js App Router deployment that the duplicate request no longer fires.

Changeset included (`patch`).

---
🤖 This fix was developed with [Claude Code](https://claude.com/claude-code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hydration so preloaded queries no longer trigger an extra background fetch when using the default cache-first behavior.
  * Prevented duplicate network requests after the server has already run the query.
  * Kept refresh behavior unchanged for network-only and cache-and-network query settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->