### PR TITLE
fix: don't let a late transported result overwrite newer cache data

### DIFF
--- a/.changeset/late-transport-clobber.md
+++ b/.changeset/late-transport-clobber.md
@@ -1,0 +1,10 @@
+---
+"@apollo/client-react-streaming": patch
+---
+
+Prevent a late-arriving SSR-transported query result from overwriting newer
+data the browser cache received in the meantime (e.g. from a mutation result,
+an optimistic update or `writeQuery`). If newer data covering any part of the
+query was written while the transported result was still in flight, the query
+is refetched in the browser instead, so the cache converges on fresh server
+data rather than reverting to a stale snapshot.

--- a/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.test.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.test.tsx
@@ -3,6 +3,7 @@ import { outsideOf } from "@internal/test-utils/runInConditions.js";
 import assert from "node:assert";
 import test, { afterEach, describe } from "node:test";
 import type {
+  ProgressEvent,
   QueryEvent,
   TransportIdentifier,
 } from "./DataTransportAbstraction.js";
@@ -367,6 +368,345 @@ describe(
         );
       }
     );
+
+    /**
+     * Runs the transported-query flow of the "race condition" test above in
+     * a plain client render (the hydration aspects are covered there), but
+     * lets the caller choose when the browser writes a newer value to the
+     * cache relative to the late-arriving transported server result.
+     */
+    async function runLateTransportScenario(
+      writeMoment: "before-transport" | "after-transport"
+    ) {
+      const { createRoot } = await import("react-dom/client");
+      // render into an own container so the scenarios don't collide with
+      // the `document.body` hydration of the test above or each other
+      const container = document.body.appendChild(
+        document.createElement("div")
+      );
+
+      const mockLink = new MockSubscriptionLink();
+      let requestCount = 0;
+      const link = new ApolloLink((operation, forward) => {
+        requestCount++;
+        return forward(operation);
+      }).concat(mockLink);
+
+      const client = new ApolloClient({
+        devtools: { enabled: false },
+        cache: new InMemoryCache(),
+        link,
+      });
+      const simulateRequestStart = client.onQueryStarted!;
+      const simulateRequestData = client.onQueryProgress!;
+
+      const Provider = WrapApolloProvider(({ children }) => {
+        return (
+          <DataTransportContext.Provider
+            value={useMemo(
+              () => ({
+                useStaticValueRef: (value: any) => ({ current: value }),
+              }),
+              []
+            )}
+          >
+            {children}
+          </DataTransportContext.Provider>
+        );
+      });
+
+      function Child() {
+        const { data } = useSuspenseQuery(QUERY_ME);
+        return <div id="user">{data.me}</div>;
+      }
+
+      // request started on the server; the browser simulates it, waiting on
+      // the transported stream
+      simulateRequestStart(
+        EVENT_STARTED as Extract<QueryEvent, { type: "started" }>
+      );
+
+      // the component deduplicates onto the simulated query and suspends
+      const root = createRoot(container);
+      await act(async () => {
+        root.render(
+          <Provider makeClient={() => client}>
+            <Suspense fallback={"Fallback"}>
+              <Child />
+            </Suspense>
+          </Provider>
+        );
+      });
+
+      const writeNewerClientValue = () =>
+        client.cache.writeQuery({
+          query: QUERY_ME,
+          data: { me: "Future me." },
+        });
+
+      // in this ordering, the browser writes newer data (think: a mutation
+      // result) while the transported result is still in flight
+      if (writeMoment === "before-transport") writeNewerClientValue();
+
+      // the transported (by now stale) server result arrives late
+      simulateRequestData(EVENT_DATA as ProgressEvent);
+      simulateRequestData(EVENT_COMPLETE as ProgressEvent);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // this ordering is already covered by the "race condition" test above
+      if (writeMoment === "after-transport") writeNewerClientValue();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const cacheBeforeNetworkResponse = JSON.parse(
+        JSON.stringify(client.extract())
+      );
+
+      // if the query was rerouted to the network, serve fresh data
+      if (requestCount > 0) {
+        mockLink.simulateResult(
+          { result: { data: { me: "Fresh me." } } },
+          true
+        );
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+
+      // in the "before" ordering, wait for the rerun's fresh result to reach
+      // the UI through the suspended query's stream; on a timeout,
+      // `renderedText` keeps whatever the UI was stuck on
+      let renderedText: string | null = null;
+      if (writeMoment === "before-transport") {
+        for (let i = 0; i < 300 && renderedText !== "Fresh me."; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          renderedText = container.querySelector("#user")?.textContent ?? null;
+        }
+      }
+      root.unmount();
+      container.remove();
+
+      return {
+        requestCount,
+        cacheBeforeNetworkResponse,
+        finalCache: JSON.parse(JSON.stringify(client.extract())),
+        renderedText,
+      };
+    }
+
+    test(
+      "late transported result: client writing after the transport resolved does not cause a refetch",
+      { skip: outsideOf("browser") },
+      async () => {
+        const { requestCount, finalCache } =
+          await runLateTransportScenario("after-transport");
+        assert.equal(requestCount, 0);
+        assert.deepStrictEqual(finalCache, {
+          ROOT_QUERY: { __typename: "Query", me: "Future me." },
+        });
+        // (that the newer client value reaches the UI in this ordering is
+        // asserted by the "race condition" test above)
+      }
+    );
+
+    test(
+      "late transported result does not overwrite a newer client cache write, but refetches in the browser",
+      { skip: outsideOf("browser") },
+      async () => {
+        const {
+          requestCount,
+          cacheBeforeNetworkResponse,
+          finalCache,
+          renderedText,
+        } = await runLateTransportScenario("before-transport");
+        // the stale transported snapshot never landed in the cache
+        assert.deepStrictEqual(cacheBeforeNetworkResponse, {
+          ROOT_QUERY: { __typename: "Query", me: "Future me." },
+        });
+        // instead, the query was rerun against the network exactly once
+        assert.equal(requestCount, 1);
+        // and the cache converged to the fresh server data
+        assert.deepStrictEqual(finalCache, {
+          ROOT_QUERY: { __typename: "Query", me: "Fresh me." },
+        });
+        // ... which also reached the UI: the query suspended on the
+        // transported stream received the rerun's result through it
+        assert.equal(renderedText, "Fresh me.");
+      }
+    );
+  }
+);
+
+describe(
+  "transported results vs. newer cache data",
+  { skip: outsideOf("browser") },
+  () => {
+    const QUERY_FULL: TypedDocumentNode<{ me: string; email: string }> = gql`
+      query {
+        me
+        email
+      }
+    `;
+    const QUERY_PARTIAL: TypedDocumentNode<{ me: string }> = gql`
+      query {
+        me
+      }
+    `;
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+    function setup() {
+      const mockLink = new MockSubscriptionLink();
+      let requestCount = 0;
+      const client = new ApolloClient({
+        devtools: { enabled: false },
+        cache: new InMemoryCache(),
+        link: new ApolloLink((operation, forward) => {
+          requestCount++;
+          return forward(operation);
+        }).concat(mockLink),
+      });
+      const started = (id: string, query: TypedDocumentNode<any>) =>
+        client.onQueryStarted!({
+          type: "started",
+          id: id as TransportIdentifier,
+          options: serializeOptions({ query }),
+        });
+      const next = (id: string, data: Record<string, unknown>) =>
+        client.onQueryProgress!({
+          type: "next",
+          id: id as TransportIdentifier,
+          value: { data },
+        } as ProgressEvent);
+      const completed = (id: string) =>
+        client.onQueryProgress!({
+          type: "completed",
+          id: id as TransportIdentifier,
+        });
+      const extract = () => JSON.parse(JSON.stringify(client.extract()));
+      return {
+        client,
+        mockLink,
+        getRequestCount: () => requestCount,
+        started,
+        next,
+        completed,
+        extract,
+      };
+    }
+
+    test("a sibling transported query's write is not treated as newer data", async () => {
+      const { started, next, completed, extract, getRequestCount } = setup();
+      started("1", QUERY_FULL);
+      started("2", QUERY_PARTIAL);
+
+      next("1", { me: "User", email: "user@example.com" });
+      completed("1");
+      // let the first query's transported result land in the cache
+      await tick();
+
+      // the second query's data is now fully contained in the cache — but it
+      // was written by the transport itself, so this is not a conflict
+      next("2", { me: "User" });
+      completed("2");
+      await tick();
+
+      assert.equal(getRequestCount(), 0);
+      assert.deepStrictEqual(extract(), {
+        ROOT_QUERY: {
+          __typename: "Query",
+          me: "User",
+          email: "user@example.com",
+        },
+      });
+    });
+
+    test("a restored persisted cache is not treated as newer data", async () => {
+      const { client, started, next, completed, extract, getRequestCount } =
+        setup();
+      // a cache persistence library restores an (older) snapshot before
+      // hydration
+      client.cache.restore({
+        ROOT_QUERY: { __typename: "Query", me: "Persisted (old)" },
+      });
+
+      started("1", QUERY_PARTIAL);
+      next("1", { me: "From server" });
+      completed("1");
+      await tick();
+
+      // the transported result is newer than the persisted snapshot and must
+      // still be applied, without a spurious refetch
+      assert.equal(getRequestCount(), 0);
+      assert.deepStrictEqual(extract(), {
+        ROOT_QUERY: { __typename: "Query", me: "From server" },
+      });
+    });
+
+    test("a client write covering only part of the query is still protected", async () => {
+      const {
+        client,
+        mockLink,
+        started,
+        next,
+        completed,
+        extract,
+        getRequestCount,
+      } = setup();
+      started("1", QUERY_FULL);
+
+      // a mutation result / writeQuery updates only one of the query's
+      // fields while the transported result is in flight
+      client.cache.writeQuery({
+        query: QUERY_PARTIAL,
+        data: { me: "Newer client value" },
+      });
+
+      next("1", { me: "Old server value", email: "old@example.com" });
+      completed("1");
+      await tick();
+
+      // the stale transported result was not written...
+      assert.deepStrictEqual(extract(), {
+        ROOT_QUERY: { __typename: "Query", me: "Newer client value" },
+      });
+      // ...instead the query was rerun against the network
+      assert.equal(getRequestCount(), 1);
+      mockLink.simulateResult(
+        { result: { data: { me: "Fresh", email: "fresh@example.com" } } },
+        true
+      );
+      await tick();
+      assert.deepStrictEqual(extract(), {
+        ROOT_QUERY: {
+          __typename: "Query",
+          me: "Fresh",
+          email: "fresh@example.com",
+        },
+      });
+    });
+
+    test("writes landing after the first chunk do not abort the stream", async () => {
+      const { client, started, next, completed, extract, getRequestCount } =
+        setup();
+      started("1", QUERY_PARTIAL);
+
+      next("1", { me: "chunk 1" });
+      await tick();
+
+      // a client write between two chunks of a multi-chunk response is not
+      // protected (documented limitation) — but it must not cause the
+      // stream to be aborted and rerun mid-flight either
+      client.cache.writeQuery({
+        query: QUERY_PARTIAL,
+        data: { me: "Client value" },
+      });
+
+      next("1", { me: "chunk 2" });
+      completed("1");
+      await tick();
+
+      assert.equal(getRequestCount(), 0);
+      assert.deepStrictEqual(extract(), {
+        ROOT_QUERY: { __typename: "Query", me: "chunk 2" },
+      });
+    });
   }
 );
 

--- a/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/WrappedApolloClient.tsx
@@ -39,6 +39,10 @@ function getQueryManager(
 type SimulatedQueryInfo = {
   controller: ReadableStreamDefaultController<ReadableStreamLinkEvent>;
   options: OrigApolloClient.WatchQueryOptions<any, OperationVariables>;
+  /** the cache's `nonTransportWrites` count when the query started (browser only) */
+  initialNonTransportWrites?: number;
+  /** the transported result has already been checked against the cache (browser only) */
+  cacheChecked?: boolean;
 };
 /** @public */
 export declare namespace ApolloClient {
@@ -158,6 +162,16 @@ class ApolloClientClientBaseImpl extends ApolloClientBase {
 
     const [controller, stream] = getInjectableEventStream();
 
+    const queryInfo: SimulatedQueryInfo = {
+      controller,
+      options: hydratedOptions,
+    };
+    if (process.env.REACT_ENV === "browser") {
+      queryInfo.initialNonTransportWrites = (
+        this.cache as InMemoryCache
+      ).nonTransportWrites;
+    }
+
     const queryManager = getQueryManager(this);
     queryManager.fetchQuery({
       ...hydratedOptions,
@@ -171,10 +185,7 @@ class ApolloClientClientBaseImpl extends ApolloClientBase {
       ),
     });
 
-    this.simulatedStreamingQueries.set(id, {
-      controller,
-      options: hydratedOptions,
-    });
+    this.simulatedStreamingQueries.set(id, queryInfo);
   }
 
   onQueryProgress = (event: ProgressEvent) => {
@@ -214,9 +225,69 @@ class ApolloClientClientBaseImpl extends ApolloClientBase {
       this.simulatedStreamingQueries.delete(event.id);
       queryInfo.controller.enqueue(event);
     } else if (event.type === "next") {
-      queryInfo.controller.enqueue(event);
+      if (
+        process.env.REACT_ENV === "browser" &&
+        !queryInfo.cacheChecked &&
+        this.wouldOverwriteNewerData(queryInfo)
+      ) {
+        this.simulatedStreamingQueries.delete(event.id);
+        invariant.debug(
+          "The cache received newer data while the query was streaming in, rerunning it in the browser:",
+          queryInfo.options
+        );
+        this.rerunSimulatedQuery(queryInfo);
+      } else {
+        // Only check before the first chunk: once a chunk is enqueued, the
+        // simulated query itself starts writing to the cache.
+        queryInfo.cacheChecked = true;
+        queryInfo.controller.enqueue(event);
+      }
     }
   };
+
+  /**
+   * Detects that data newer than this query's transported result was written
+   * to the cache while the result was in flight.
+   *
+   * The transported result is a snapshot from the SSR render. If anything
+   * outside the transport — a mutation result, an optimistic update, a
+   * direct `writeQuery` — has written to the cache since this query started,
+   * and any of this query's fields can now be read from the cache, writing
+   * the transported result could overwrite newer data with the server's
+   * older snapshot, so the query is rerun in the browser instead and the
+   * cache converges on fresh data.
+   * Writes by the transport itself — sibling transported queries,
+   * transported query refs, a restored persisted cache — don't count: they
+   * are not newer than this result.
+   *
+   * Not detected: non-transport writes landing before this query's `started`
+   * event was replayed in the browser or in the short gap between this check
+   * and the transported result's cache write, and writes landing between the
+   * chunks of a multi-chunk (`@defer`) response — later chunks can still
+   * overwrite newer data. Queries containing `@client` fields resolved by
+   * local resolvers are misclassified in the opposite (safe) direction:
+   * their cache writes happen asynchronously after delivery and are counted
+   * as non-transport writes, which can cause a spurious browser refetch of
+   * an overlapping transported query, but never an overwrite.
+   */
+  private wouldOverwriteNewerData(queryInfo: SimulatedQueryInfo) {
+    const cache = this.cache as InMemoryCache;
+    if (cache.nonTransportWrites === queryInfo.initialNonTransportWrites) {
+      return false;
+    }
+    const queryManager = getQueryManager(this);
+    const diff = cache.diff({
+      query: queryManager.transform(queryInfo.options.query),
+      variables: queryInfo.options.variables,
+      optimistic: true,
+      returnPartialData: true,
+    });
+    const result = diff.result as Record<string, unknown> | null;
+    // A root-level fragment or an explicit root `__typename` selection can
+    // always be fulfilled with `{ __typename: "Query" }`, even from an empty
+    // cache — that alone is no evidence of newer data.
+    return !!result && Object.keys(result).some((key) => key !== "__typename");
+  }
 
   /**
    * Can be called when the stream closed unexpectedly while there might still be unresolved

--- a/packages/client-react-streaming/src/DataTransportAbstraction/WrappedInMemoryCache.tsx
+++ b/packages/client-react-streaming/src/DataTransportAbstraction/WrappedInMemoryCache.tsx
@@ -1,14 +1,16 @@
-import type { InMemoryCacheConfig } from "@apollo/client";
+import type {
+  Cache,
+  InMemoryCacheConfig,
+  OperationVariables,
+  Reference,
+} from "@apollo/client";
 import { InMemoryCache as OrigInMemoryCache } from "@apollo/client";
 import { bundle, sourceSymbol } from "../bundleInfo.js";
+import { isTransportEmission } from "../ReadableStreamLink.js";
 /*
- * We just subclass `InMemoryCache` here so that `WrappedApolloClient`
+ * We subclass `InMemoryCache` here so that `WrappedApolloClient`
  * can detect if it was initialized with an `InMemoryCache` instance that
  * was also exported from this package.
- * Right now, we don't have extra logic here, but we might have so again
- * in the future.
- * So we want to enforce this import path from the start to prevent future
- * subtle bugs if people update the package and don't read the patch notes.
  */
 /**
  * A version of `InMemoryCache` to be used with streaming SSR.
@@ -29,5 +31,40 @@ export class InMemoryCache extends OrigInMemoryCache {
     super(config);
     const info = (this.constructor as typeof InMemoryCache).info;
     this[sourceSymbol] = `${info.pkg}:InMemoryCache`;
+  }
+
+  /**
+   * Counts cache writes that did not originate from the SSR data transport —
+   * e.g. mutation results, optimistic updates, or direct `writeQuery`/
+   * `writeFragment`/`modify`/`evict` calls.
+   * `WrappedApolloClient` compares this before and after a transported query
+   * result was in flight to detect that the (older) transported result would
+   * overwrite newer data.
+   * @internal
+   */
+  nonTransportWrites = 0;
+
+  write<
+    TData = unknown,
+    TVariables extends OperationVariables = OperationVariables,
+  >(options: Cache.WriteOptions<TData, TVariables>): Reference | undefined {
+    if (!isTransportEmission()) this.nonTransportWrites++;
+    return super.write(options);
+  }
+
+  modify<Entity extends Record<string, any> = Record<string, any>>(
+    options: Cache.ModifyOptions<Entity>
+  ): boolean {
+    // `modify` and `evict` report whether they changed anything — no-ops
+    // don't count as writes.
+    const modified = super.modify(options);
+    if (modified && !isTransportEmission()) this.nonTransportWrites++;
+    return modified;
+  }
+
+  evict(options: Cache.EvictOptions): boolean {
+    const evicted = super.evict(options);
+    if (evicted && !isTransportEmission()) this.nonTransportWrites++;
+    return evicted;
   }
 }

--- a/packages/client-react-streaming/src/ReadableStreamLink.tsx
+++ b/packages/client-react-streaming/src/ReadableStreamLink.tsx
@@ -31,6 +31,39 @@ const teeToReadableStreamKey = Symbol.for(
 );
 const readFromReadableStreamKey = Symbol.for("apollo.read.readableStream");
 
+/*
+ * The emission depth lives on `globalThis` (like the other `Symbol.for`
+ * keys in this file) so that it is shared even when multiple copies of this
+ * module are loaded side by side (dual CJS/ESM loading, the separately
+ * bundled `.cc` entry points, or mixed package versions).
+ */
+const transportEmissionDepth = Symbol.for("apollo.transport.emissionDepth");
+interface GlobalWithTransportEmissionDepth {
+  [transportEmissionDepth]?: number;
+}
+
+/**
+ * Whether the current (synchronous) call stack is replaying a result read
+ * from a transported readable stream — as opposed to delivering e.g. a
+ * mutation result or a fresh network response. Cache writes happen
+ * synchronously while a link result is delivered, so this allows the cache
+ * to tell writes that replay a transported (SSR-time) snapshot apart from
+ * writes of newer data.
+ * @internal
+ */
+export function isTransportEmission() {
+  return (
+    ((globalThis as GlobalWithTransportEmissionDepth)[transportEmissionDepth] ??
+      0) > 0
+  );
+}
+
+function adjustTransportEmissionDepth(delta: number) {
+  const global = globalThis as GlobalWithTransportEmissionDepth;
+  global[transportEmissionDepth] =
+    (global[transportEmissionDepth] ?? 0) + delta;
+}
+
 /**
  * Apply to a context that will be passed to a link chain containing `TeeToReadableStreamLink`.
  * @public
@@ -174,9 +207,18 @@ export class ReadFromReadableStreamLink extends ApolloLink {
               if (aborted) break;
               if (event.value) {
                 switch (event.value.type) {
-                  case "next":
-                    observer.next(event.value.value);
+                  case "next": {
+                    // Mark the delivery so cache writes it causes are
+                    // recognized as replaying a transported (SSR-time)
+                    // snapshot rather than writing newer data.
+                    adjustTransportEmissionDepth(1);
+                    try {
+                      observer.next(event.value.value);
+                    } finally {
+                      adjustTransportEmissionDepth(-1);
+                    }
                     break;
+                  }
                   case "completed":
                     observer.complete();
                     break;


### PR DESCRIPTION
## The bug

A field reverts to a stale value a second or so after a mutation, with no user
interaction. It's a race in the streaming SSR transport.

A query that ran on the server gets replayed in the browser as a
`network-only` fetch fed by the transported stream (`onQueryStarted`). That
result can land late, and being `network-only` it writes to the cache
unconditionally. So if the browser wrote newer data for those fields in the
meantime (a mutation result, an optimistic update, a `writeQuery`), the late
write clobbers it with the server's older snapshot.

## The fix

Before applying the first transported chunk, `onQueryProgress` checks whether
newer (non-transport) data was written to this query since it started.
If so, the stale result is dropped and the query reruns in the browser via the
existing "failed on server" path, so the cache ends up on fresh data.

To tell transport writes from real ones, `ReadFromReadableStreamLink` marks its
stream replays and the `InMemoryCache` subclass counts everything else. Using a
counter rather than diffing the cache on arrival keeps the happy path from
touching the cache at all, and means sibling transported queries, a restored
persisted cache, etc. don't trip it, while partial mutation writes still do.

## Tests

Six, on the existing harness: write-after (no refetch), write-before (the bug,
fails on `main`), plus sibling query / persisted cache / partial write / defer
cases. Also verified end-to-end in a Next.js app: the field reverts on `main`
and doesn't with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented late server-rendered query results from overwriting newer browser cache data.
  * Automatically refetches affected queries so the cache and displayed data converge on fresh server results.
  * Improved handling of partial updates and streamed responses without unnecessarily interrupting in-flight transfers.
* **Tests**
  * Added coverage for cache updates occurring before, during, and after streamed result delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->